### PR TITLE
Issue #4: Deterministic mock PTY harness

### DIFF
--- a/.squad/agents/switch/history.md
+++ b/.squad/agents/switch/history.md
@@ -109,5 +109,13 @@
 - **Decision gates merged:** Replay buffer scope, overflow behavior, generation reset boundary, trust-boundary enforcement all documented in `.squad/decisions.md`
 - **Next:** Incorporate Switch's remaining high-risk coverage before signoff; merge to unblock Phase 2 grain implementation
 
+### Issue #4 Mock PTY Harness (2026-03-25)
+
+- **Reusable PTY seam:** Phase 1 now has a broker-local PTY abstraction under `src\SquadScout.Broker\Pty\` with `IPtyHost`, `IPtySession`, `PtySessionStartRequest`, and `PtySessionEvent`. The seam stays lifecycle/stream oriented so issue #5 can swap in a real Copilot host without replay refactoring.
+- **Deterministic harness pattern:** `MockPtySession` uses logical ticks plus explicit `ReleaseNext()` / `AdvanceBy()` controls instead of wall-clock sleeps. That keeps chunking, exit injection, and cancellation coverage stable in CI and fast locally.
+- **Relay/test fixture pattern:** `tests\SquadScout.Broker.Tests\TestDoubles\MockPtyHarnessFixture.cs` pumps PTY lifecycle/output events through `InMemorySessionOrchestrator` and `RecordingRelayPublisher` so tests can assert sequencing, relay publication order, replay windows, and session state transitions in one offline slice.
+- **Contract additions:** Typed payloads for `Input`, `Output`, and `SessionLifecycle` now live in `src\SquadScout.Contracts\Messages\`. `SessionRuntimeState` updates `SessionDescriptor.State` from `SessionLifecyclePayload`, and `IRelayPublisher` can now capture broker envelopes via `PublishEnvelopeAsync`.
+- **Verification:** `dotnet build .\SquadScout.slnx -nologo` and `dotnet test .\SquadScout.slnx -nologo --no-build` both pass with 28/28 tests, including the new `MockPtySessionTests` and `MockPtyHarnessIntegrationTests`.
+
 
 

--- a/.squad/decisions/inbox/switch-issue-4.md
+++ b/.squad/decisions/inbox/switch-issue-4.md
@@ -1,0 +1,32 @@
+# Switch Decision Note — Issue #4 Mock PTY Harness
+
+- **Requested by:** Ryan Graham
+- **Branch:** `squad/4-mock-pty-harness`
+- **Issue:** #4 Mock PTY Harness
+
+## Decision
+
+Adopt a two-layer PTY seam:
+
+1. **Broker-facing host contract:** `src\SquadScout.Broker\Pty\IPtyHost.cs` starts PTY sessions from `PtySessionStartRequest`.
+2. **Per-session PTY contract:** `src\SquadScout.Broker\Pty\IPtySession.cs` owns raw writes, event reads, termination, and lifecycle state.
+
+The mock implementation (`MockPtyHost` / `MockPtySession`) stays **event oriented** and emits `PtySessionEvent` values (`Started`, `Output`, `Exited`) with deterministic logical-tick scheduling. It does **not** mint broker envelopes, sequence numbers, replay metadata, or transport concerns.
+
+## Why
+
+- Preserves Link's seam requirement that PTY simulation stay host-shaped and transport-free.
+- Keeps sequencing/replay ownership in `src\SquadScout.Broker\Sessions\`.
+- Gives issue #5 a drop-in contract for the real Copilot PTY host.
+- Gives issue #6 a clean place to translate PTY events into broker envelopes and relay publication.
+
+## Coupled follow-on choices
+
+- `IRelayPublisher` now exposes `PublishEnvelopeAsync<TPayload>` so tests and later relay code can observe broker envelope publication without hiding sequencing inside ad hoc helpers.
+- `SessionRuntimeState` updates `SessionDescriptor.State` when it records `SessionLifecyclePayload`, making running/stopped transitions visible through `ISessionOrchestrator.GetAsync`.
+- Typed payloads now exist for `Input`, `Output`, and `SessionLifecycle` under `src\SquadScout.Contracts\Messages\`.
+
+## Verification
+
+- `dotnet build .\SquadScout.slnx -nologo`
+- `dotnet test .\SquadScout.slnx -nologo --no-build`

--- a/.squad/skills/deterministic-mock-pty-harness/SKILL.md
+++ b/.squad/skills/deterministic-mock-pty-harness/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: "deterministic-mock-pty-harness"
+description: "Patterns for building a transport-free PTY simulator that proves broker datapaths in fast offline tests"
+domain: "testing"
+confidence: "medium"
+source: "earned"
+---
+
+## Context
+
+Use this skill when a broker needs to prove PTY-driven input/output, lifecycle, sequencing, and replay behavior before a real PTY dependency or cloud relay is available. It is especially useful for Phase 1 style slices where the goal is deterministic CI coverage, not process fidelity.
+
+## Patterns
+
+- **Split host from session:** Keep a broker-level `IPtyHost` that starts sessions and a per-session `IPtySession` that owns writes, reads, termination, and lifecycle state.
+- **Emit PTY events, not broker envelopes:** The PTY seam should surface `Started`, `Output`, and `Exited` events. Let the broker/session layer translate those into sequenced envelopes.
+- **Use logical ticks instead of sleeps:** Mock PTY timing should advance via explicit `AdvanceBy(...)` or `ReleaseNext()` controls so chunking and exit ordering stay reproducible in CI.
+- **Keep mock controls mock-specific:** Deterministic scheduling helpers, queued failures, and captured writes should live on the mock implementation, not on the shared PTY interface.
+- **Capture relay publication separately:** Pair the PTY mock with a recording relay publisher and a small test fixture that pumps events through the broker orchestration layer. This lets one test assert chunk boundaries, relay order, replay windows, and visible session state.
+- **Model lifecycle with typed payloads:** Use explicit `SessionLifecyclePayload` and `OutputChunkPayload` types so later relay work does not depend on anonymous payloads or `JsonElement` guesses.
+
+## Examples
+
+- `src\SquadScout.Broker\Pty\IPtyHost.cs`
+- `src\SquadScout.Broker\Pty\IPtySession.cs`
+- `src\SquadScout.Broker\Pty\MockPtySession.cs`
+- `tests\SquadScout.Broker.Tests\TestDoubles\MockPtyHarnessFixture.cs`
+- `tests\SquadScout.Broker.Tests\MockPtyHarnessIntegrationTests.cs`
+
+## Anti-Patterns
+
+- Do not let the PTY mock assign broker sequence numbers or replay metadata.
+- Do not use wall-clock sleeps, timers, or background polling to release output.
+- Do not couple the PTY contract to Web PubSub, HTTP, or message-envelope types.
+- Do not hide lifecycle transitions inside opaque test helpers; surface them as explicit PTY events and broker lifecycle payloads.

--- a/src/SquadScout.Broker/Pty/IPtyHost.cs
+++ b/src/SquadScout.Broker/Pty/IPtyHost.cs
@@ -1,0 +1,6 @@
+namespace SquadScout.Broker.Pty;
+
+public interface IPtyHost
+{
+    Task<IPtySession> StartSessionAsync(PtySessionStartRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/SquadScout.Broker/Pty/IPtySession.cs
+++ b/src/SquadScout.Broker/Pty/IPtySession.cs
@@ -1,0 +1,20 @@
+using SquadScout.Contracts.Sessions;
+
+namespace SquadScout.Broker.Pty;
+
+public interface IPtySession : IAsyncDisposable
+{
+    string SessionId { get; }
+
+    string ProjectId { get; }
+
+    SessionState State { get; }
+
+    Task WriteAsync(string input, CancellationToken cancellationToken = default);
+
+    bool TryReadEvent(out PtySessionEvent @event);
+
+    ValueTask<PtySessionEvent> ReadEventAsync(CancellationToken cancellationToken = default);
+
+    Task TerminateAsync(CancellationToken cancellationToken = default);
+}

--- a/src/SquadScout.Broker/Pty/MockPtyHost.cs
+++ b/src/SquadScout.Broker/Pty/MockPtyHost.cs
@@ -1,0 +1,73 @@
+using System.Collections.Concurrent;
+
+namespace SquadScout.Broker.Pty;
+
+public sealed class MockPtyHost : IPtyHost
+{
+    private readonly object _syncRoot = new();
+    private readonly Queue<Exception> _startFailures = new();
+    private readonly List<PtySessionStartRequest> _startRequests = [];
+    private readonly ConcurrentDictionary<string, MockPtySession> _sessions = new(StringComparer.OrdinalIgnoreCase);
+
+    public IReadOnlyList<PtySessionStartRequest> StartRequests
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _startRequests.ToArray();
+            }
+        }
+    }
+
+    public void FailNextStart(Exception? exception = null)
+    {
+        lock (_syncRoot)
+        {
+            _startFailures.Enqueue(exception ?? new InvalidOperationException("The mock PTY host failed to start."));
+        }
+    }
+
+    public MockPtySession GetRequiredSession(string sessionId)
+    {
+        if (_sessions.TryGetValue(sessionId, out var session))
+        {
+            return session;
+        }
+
+        throw new KeyNotFoundException($"Mock PTY session '{sessionId}' was not found.");
+    }
+
+    public Task<IPtySession> StartSessionAsync(PtySessionStartRequest request, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(request.SessionId))
+        {
+            throw new ArgumentException("A session id is required.", nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ProjectId))
+        {
+            throw new ArgumentException("A project id is required.", nameof(request));
+        }
+
+        lock (_syncRoot)
+        {
+            if (_startFailures.TryDequeue(out var exception))
+            {
+                throw exception;
+            }
+
+            _startRequests.Add(request);
+        }
+
+        var session = new MockPtySession(request);
+        if (!_sessions.TryAdd(session.SessionId, session))
+        {
+            throw new InvalidOperationException($"Mock PTY session '{session.SessionId}' already exists.");
+        }
+
+        return Task.FromResult<IPtySession>(session);
+    }
+}

--- a/src/SquadScout.Broker/Pty/MockPtySession.cs
+++ b/src/SquadScout.Broker/Pty/MockPtySession.cs
@@ -1,0 +1,257 @@
+using System.Threading.Channels;
+using SquadScout.Contracts.Sessions;
+
+namespace SquadScout.Broker.Pty;
+
+public sealed class MockPtySession : IPtySession
+{
+    private readonly Channel<PtySessionEvent> _events = Channel.CreateUnbounded<PtySessionEvent>();
+    private readonly PriorityQueue<ScheduledEvent, (int DueTick, long Order)> _scheduledEvents = new();
+    private readonly object _syncRoot = new();
+    private readonly List<string> _writtenInputs = [];
+    private bool _disposed;
+    private bool _exitPublished;
+    private int _currentTick;
+    private long _nextEventOrder;
+
+    public MockPtySession(PtySessionStartRequest request)
+    {
+        Request = request ?? throw new ArgumentNullException(nameof(request));
+        SessionId = request.SessionId;
+        ProjectId = request.ProjectId;
+        State = SessionState.Running;
+        PublishEventLocked(PtySessionEvent.Started());
+    }
+
+    public PtySessionStartRequest Request { get; }
+
+    public string SessionId { get; }
+
+    public string ProjectId { get; }
+
+    public SessionState State { get; private set; }
+
+    public int CurrentTick
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _currentTick;
+            }
+        }
+    }
+
+    public int PendingScheduledEventCount
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _scheduledEvents.Count;
+            }
+        }
+    }
+
+    public IReadOnlyList<string> WrittenInputs
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _writtenInputs.ToArray();
+            }
+        }
+    }
+
+    public void EnqueueOutput(string content, int afterTicks = 0, bool isError = false, DateTimeOffset? timestampUtc = null)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        Schedule(PtySessionEvent.Output(content, isError, timestampUtc), afterTicks);
+    }
+
+    public void EnqueueExit(int? exitCode = 0, int afterTicks = 0, DateTimeOffset? timestampUtc = null) =>
+        Schedule(PtySessionEvent.Exited(exitCode, timestampUtc), afterTicks);
+
+    public int AdvanceBy(int ticks)
+    {
+        if (ticks < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(ticks), ticks, "Advance ticks must be non-negative.");
+        }
+
+        lock (_syncRoot)
+        {
+            ThrowIfDisposed();
+            _currentTick += ticks;
+            return ReleaseDueEventsLocked();
+        }
+    }
+
+    public bool ReleaseNext()
+    {
+        lock (_syncRoot)
+        {
+            ThrowIfDisposed();
+            if (!_scheduledEvents.TryPeek(out _, out var due))
+            {
+                return false;
+            }
+
+            _currentTick = Math.Max(_currentTick, due.DueTick);
+            ReleaseNextScheduledEventLocked();
+            return true;
+        }
+    }
+
+    public int ReleaseAll()
+    {
+        lock (_syncRoot)
+        {
+            ThrowIfDisposed();
+            var released = 0;
+            while (_scheduledEvents.Count > 0)
+            {
+                ReleaseNextScheduledEventLocked();
+                released++;
+            }
+
+            return released;
+        }
+    }
+
+    public Task WriteAsync(string input, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(input);
+
+        lock (_syncRoot)
+        {
+            ThrowIfDisposed();
+
+            if (State == SessionState.Stopped)
+            {
+                throw new InvalidOperationException("Cannot write to a stopped PTY session.");
+            }
+
+            _writtenInputs.Add(input);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public bool TryReadEvent(out PtySessionEvent @event) => _events.Reader.TryRead(out @event);
+
+    public ValueTask<PtySessionEvent> ReadEventAsync(CancellationToken cancellationToken = default) =>
+        _events.Reader.ReadAsync(cancellationToken);
+
+    public Task TerminateAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_syncRoot)
+        {
+            if (_disposed || State == SessionState.Stopped)
+            {
+                return Task.CompletedTask;
+            }
+
+            _scheduledEvents.Clear();
+            PublishExitLocked(null);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        await TerminateAsync().ConfigureAwait(false);
+
+        lock (_syncRoot)
+        {
+            _disposed = true;
+            _events.Writer.TryComplete();
+        }
+    }
+
+    private void Schedule(PtySessionEvent @event, int afterTicks)
+    {
+        if (afterTicks < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(afterTicks), afterTicks, "Scheduled ticks must be non-negative.");
+        }
+
+        lock (_syncRoot)
+        {
+            ThrowIfDisposed();
+
+            if (_exitPublished)
+            {
+                throw new InvalidOperationException("Cannot schedule PTY events after the session has exited.");
+            }
+
+            var dueTick = checked(_currentTick + afterTicks);
+            _scheduledEvents.Enqueue(new ScheduledEvent(@event), (dueTick, _nextEventOrder++));
+        }
+    }
+
+    private int ReleaseDueEventsLocked()
+    {
+        var released = 0;
+        while (_scheduledEvents.TryPeek(out _, out var due) && due.DueTick <= _currentTick)
+        {
+            ReleaseNextScheduledEventLocked();
+            released++;
+        }
+
+        return released;
+    }
+
+    private void ReleaseNextScheduledEventLocked()
+    {
+        var scheduledEvent = _scheduledEvents.Dequeue();
+        switch (scheduledEvent.Event.Kind)
+        {
+            case PtySessionEventKind.Output:
+                PublishEventLocked(scheduledEvent.Event);
+                break;
+            case PtySessionEventKind.Exited:
+                PublishExitLocked(scheduledEvent.Event.ExitCode);
+                break;
+            default:
+                PublishEventLocked(scheduledEvent.Event);
+                break;
+        }
+    }
+
+    private void PublishExitLocked(int? exitCode)
+    {
+        if (_exitPublished)
+        {
+            return;
+        }
+
+        State = SessionState.Stopped;
+        _exitPublished = true;
+        PublishEventLocked(PtySessionEvent.Exited(exitCode));
+        _events.Writer.TryComplete();
+    }
+
+    private void PublishEventLocked(PtySessionEvent @event)
+    {
+        _events.Writer.TryWrite(@event);
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
+    private sealed record ScheduledEvent(PtySessionEvent Event);
+}

--- a/src/SquadScout.Broker/Pty/PtySessionEvent.cs
+++ b/src/SquadScout.Broker/Pty/PtySessionEvent.cs
@@ -1,0 +1,42 @@
+namespace SquadScout.Broker.Pty;
+
+public sealed record PtySessionEvent
+{
+    public PtySessionEventKind Kind { get; init; }
+
+    public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
+
+    public string? Content { get; init; }
+
+    public bool IsError { get; init; }
+
+    public int? ExitCode { get; init; }
+
+    public static PtySessionEvent Started(DateTimeOffset? timestampUtc = null) =>
+        new()
+        {
+            Kind = PtySessionEventKind.Started,
+            TimestampUtc = timestampUtc ?? DateTimeOffset.UtcNow
+        };
+
+    public static PtySessionEvent Output(string content, bool isError = false, DateTimeOffset? timestampUtc = null)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        return new PtySessionEvent
+        {
+            Kind = PtySessionEventKind.Output,
+            TimestampUtc = timestampUtc ?? DateTimeOffset.UtcNow,
+            Content = content,
+            IsError = isError
+        };
+    }
+
+    public static PtySessionEvent Exited(int? exitCode, DateTimeOffset? timestampUtc = null) =>
+        new()
+        {
+            Kind = PtySessionEventKind.Exited,
+            TimestampUtc = timestampUtc ?? DateTimeOffset.UtcNow,
+            ExitCode = exitCode
+        };
+}

--- a/src/SquadScout.Broker/Pty/PtySessionEventKind.cs
+++ b/src/SquadScout.Broker/Pty/PtySessionEventKind.cs
@@ -1,0 +1,8 @@
+namespace SquadScout.Broker.Pty;
+
+public enum PtySessionEventKind
+{
+    Started = 0,
+    Output = 1,
+    Exited = 2
+}

--- a/src/SquadScout.Broker/Pty/PtySessionStartRequest.cs
+++ b/src/SquadScout.Broker/Pty/PtySessionStartRequest.cs
@@ -1,0 +1,12 @@
+namespace SquadScout.Broker.Pty;
+
+public sealed record PtySessionStartRequest
+{
+    public string SessionId { get; init; } = string.Empty;
+
+    public string ProjectId { get; init; } = string.Empty;
+
+    public string WorkingDirectory { get; init; } = string.Empty;
+
+    public string[] Arguments { get; init; } = Array.Empty<string>();
+}

--- a/src/SquadScout.Broker/Relay/IRelayPublisher.cs
+++ b/src/SquadScout.Broker/Relay/IRelayPublisher.cs
@@ -1,3 +1,4 @@
+using SquadScout.Contracts.Messages;
 using SquadScout.Contracts.Sessions;
 
 namespace SquadScout.Broker.Relay;
@@ -5,4 +6,6 @@ namespace SquadScout.Broker.Relay;
 public interface IRelayPublisher
 {
     Task PublishSessionStartedAsync(SessionDescriptor session, CancellationToken cancellationToken = default);
+
+    Task PublishEnvelopeAsync<TPayload>(MessageEnvelope<TPayload> envelope, CancellationToken cancellationToken = default);
 }

--- a/src/SquadScout.Broker/Relay/NullRelayPublisher.cs
+++ b/src/SquadScout.Broker/Relay/NullRelayPublisher.cs
@@ -1,8 +1,11 @@
 using SquadScout.Contracts.Sessions;
+using SquadScout.Contracts.Messages;
 
 namespace SquadScout.Broker.Relay;
 
 public sealed class NullRelayPublisher : IRelayPublisher
 {
     public Task PublishSessionStartedAsync(SessionDescriptor session, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public Task PublishEnvelopeAsync<TPayload>(MessageEnvelope<TPayload> envelope, CancellationToken cancellationToken = default) => Task.CompletedTask;
 }

--- a/src/SquadScout.Broker/Sessions/InMemorySessionOrchestrator.cs
+++ b/src/SquadScout.Broker/Sessions/InMemorySessionOrchestrator.cs
@@ -25,7 +25,15 @@ public sealed class InMemorySessionOrchestrator : ISessionOrchestrator
     public Task<SessionDescriptor?> GetAsync(string sessionId, CancellationToken cancellationToken = default)
     {
         _sessions.TryGetValue(sessionId, out var session);
-        return Task.FromResult(session?.Descriptor);
+        if (session is null)
+        {
+            return Task.FromResult<SessionDescriptor?>(null);
+        }
+
+        lock (session.SyncRoot)
+        {
+            return Task.FromResult<SessionDescriptor?>(session.Descriptor);
+        }
     }
 
     public async Task<SessionDescriptor> StartAsync(StartSessionCommand command, CancellationToken cancellationToken = default)
@@ -57,10 +65,13 @@ public sealed class InMemorySessionOrchestrator : ISessionOrchestrator
         cancellationToken.ThrowIfCancellationRequested();
 
         var state = GetRequiredSessionState(sessionId);
+        MessageEnvelope<TPayload> envelope;
         lock (state.SyncRoot)
         {
-            return Task.FromResult(state.CreateBrokerEnvelope(command));
+            envelope = state.CreateBrokerEnvelope(command);
         }
+
+        return PublishBrokerEnvelopeAsync(envelope, cancellationToken);
     }
 
     public Task<SequenceValidationResult> ValidateClientMessageAsync<TPayload>(
@@ -151,5 +162,13 @@ public sealed class InMemorySessionOrchestrator : ISessionOrchestrator
         {
             throw new ArgumentException("Envelope project id does not match the targeted session.", nameof(envelope));
         }
+    }
+
+    private async Task<MessageEnvelope<TPayload>> PublishBrokerEnvelopeAsync<TPayload>(
+        MessageEnvelope<TPayload> envelope,
+        CancellationToken cancellationToken)
+    {
+        await _relayPublisher.PublishEnvelopeAsync(envelope, cancellationToken);
+        return envelope;
     }
 }

--- a/src/SquadScout.Broker/Sessions/SessionRuntimeState.cs
+++ b/src/SquadScout.Broker/Sessions/SessionRuntimeState.cs
@@ -14,7 +14,7 @@ internal sealed class SessionRuntimeState
         _replayBuffer = new CircularReplayBuffer(replayBufferCapacity);
     }
 
-    public SessionDescriptor Descriptor { get; }
+    public SessionDescriptor Descriptor { get; private set; }
 
     public object SyncRoot { get; } = new();
 
@@ -95,6 +95,11 @@ internal sealed class SessionRuntimeState
         if (envelope.Sequence is not null)
         {
             _replayBuffer.Append(ToSnapshot(envelope));
+        }
+
+        if (command.MessageType == SessionMessageType.SessionLifecycle && command.Payload is SessionLifecyclePayload lifecycle)
+        {
+            Descriptor = Descriptor with { State = lifecycle.State };
         }
 
         return envelope;

--- a/src/SquadScout.Contracts/Messages/InputChunkPayload.cs
+++ b/src/SquadScout.Contracts/Messages/InputChunkPayload.cs
@@ -1,0 +1,6 @@
+namespace SquadScout.Contracts.Messages;
+
+public sealed record InputChunkPayload
+{
+    public string Content { get; init; } = string.Empty;
+}

--- a/src/SquadScout.Contracts/Messages/OutputChunkPayload.cs
+++ b/src/SquadScout.Contracts/Messages/OutputChunkPayload.cs
@@ -1,0 +1,8 @@
+namespace SquadScout.Contracts.Messages;
+
+public sealed record OutputChunkPayload
+{
+    public string Content { get; init; } = string.Empty;
+
+    public bool IsError { get; init; }
+}

--- a/src/SquadScout.Contracts/Messages/SessionLifecyclePayload.cs
+++ b/src/SquadScout.Contracts/Messages/SessionLifecyclePayload.cs
@@ -1,0 +1,12 @@
+using SquadScout.Contracts.Sessions;
+
+namespace SquadScout.Contracts.Messages;
+
+public sealed record SessionLifecyclePayload
+{
+    public SessionState State { get; init; } = SessionState.Pending;
+
+    public string Reason { get; init; } = string.Empty;
+
+    public int? ExitCode { get; init; }
+}

--- a/tests/SquadScout.Broker.Tests/MockPtyHarnessIntegrationTests.cs
+++ b/tests/SquadScout.Broker.Tests/MockPtyHarnessIntegrationTests.cs
@@ -1,0 +1,77 @@
+using SquadScout.Broker.Tests.TestDoubles;
+using SquadScout.Contracts.Messages;
+using SquadScout.Contracts.Sessions;
+
+namespace SquadScout.Broker.Tests;
+
+public sealed class MockPtyHarnessIntegrationTests
+{
+    [Fact]
+    public async Task PumpsDeterministicPtyEventsThroughRelaySequencingAndReplay()
+    {
+        var harness = new MockPtyHarnessFixture(replayBufferCapacity: 8);
+        var session = await harness.StartAsync("--project", "broker");
+
+        await harness.PtySession.WriteAsync("explain testability\n");
+        harness.PtySession.EnqueueOutput("hel", afterTicks: 1);
+        harness.PtySession.EnqueueOutput("lo", afterTicks: 2);
+        harness.PtySession.EnqueueExit(0, afterTicks: 3);
+
+        Assert.Equal(["explain testability\n"], harness.PtySession.WrittenInputs);
+
+        harness.PtySession.AdvanceBy(1);
+        await harness.PumpAvailableAsync();
+
+        harness.PtySession.AdvanceBy(2);
+        await harness.PumpAvailableAsync();
+
+        var published = harness.RelayPublisher.PublishedEnvelopes;
+        Assert.Single(harness.RelayPublisher.StartedSessions);
+        Assert.Equal(session.SessionId, harness.RelayPublisher.StartedSessions[0].SessionId);
+
+        Assert.Collection(
+            published,
+            message =>
+            {
+                Assert.Equal(1, message.Sequence);
+                Assert.Equal(SessionMessageType.SessionLifecycle, message.MessageType);
+                var payload = MockPtyHarnessFixture.DeserializePayload<SessionLifecyclePayload>(message);
+                Assert.Equal(SessionState.Running, payload.State);
+                Assert.Equal("pty-started", payload.Reason);
+            },
+            message =>
+            {
+                Assert.Equal(2, message.Sequence);
+                Assert.Equal(SessionMessageType.Output, message.MessageType);
+                var payload = MockPtyHarnessFixture.DeserializePayload<OutputChunkPayload>(message);
+                Assert.Equal("hel", payload.Content);
+                Assert.False(payload.IsError);
+            },
+            message =>
+            {
+                Assert.Equal(3, message.Sequence);
+                Assert.Equal(SessionMessageType.Output, message.MessageType);
+                var payload = MockPtyHarnessFixture.DeserializePayload<OutputChunkPayload>(message);
+                Assert.Equal("lo", payload.Content);
+                Assert.False(payload.IsError);
+            },
+            message =>
+            {
+                Assert.Equal(4, message.Sequence);
+                Assert.Equal(SessionMessageType.SessionLifecycle, message.MessageType);
+                var payload = MockPtyHarnessFixture.DeserializePayload<SessionLifecyclePayload>(message);
+                Assert.Equal(SessionState.Stopped, payload.State);
+                Assert.Equal(0, payload.ExitCode);
+            });
+
+        var replay = await harness.Orchestrator.ReplayAsync(session.SessionId, harness.CreateReplayRequest(fromSequenceInclusive: 1));
+        Assert.Equal(1, replay.Payload.FromSequenceInclusive);
+        Assert.Equal(4, replay.Payload.ToSequenceInclusive);
+        Assert.False(replay.Payload.GapDetected);
+        Assert.Equal(4, replay.Payload.Messages.Count);
+
+        var descriptor = await harness.Orchestrator.GetAsync(session.SessionId);
+        Assert.NotNull(descriptor);
+        Assert.Equal(SessionState.Stopped, descriptor!.State);
+    }
+}

--- a/tests/SquadScout.Broker.Tests/MockPtySessionTests.cs
+++ b/tests/SquadScout.Broker.Tests/MockPtySessionTests.cs
@@ -1,0 +1,126 @@
+using SquadScout.Broker.Pty;
+using SquadScout.Contracts.Sessions;
+
+namespace SquadScout.Broker.Tests;
+
+public sealed class MockPtySessionTests
+{
+    [Fact]
+    public async Task AdvancesChunkedOutputByLogicalTicks()
+    {
+        var session = new MockPtySession(new PtySessionStartRequest
+        {
+            ProjectId = "broker",
+            SessionId = "session-123"
+        });
+
+        session.EnqueueOutput("hel", afterTicks: 1);
+        session.EnqueueOutput("lo", afterTicks: 2);
+        session.EnqueueExit(0, afterTicks: 3);
+
+        var started = await session.ReadEventAsync();
+        Assert.Equal(PtySessionEventKind.Started, started.Kind);
+        Assert.Equal(SessionState.Running, session.State);
+
+        Assert.Equal(1, session.AdvanceBy(1));
+        Assert.True(session.TryReadEvent(out var firstChunk));
+        Assert.Equal(PtySessionEventKind.Output, firstChunk.Kind);
+        Assert.Equal("hel", firstChunk.Content);
+
+        Assert.Equal(1, session.AdvanceBy(1));
+        Assert.True(session.TryReadEvent(out var secondChunk));
+        Assert.Equal("lo", secondChunk.Content);
+
+        Assert.Equal(1, session.AdvanceBy(1));
+        Assert.True(session.TryReadEvent(out var exited));
+        Assert.Equal(PtySessionEventKind.Exited, exited.Kind);
+        Assert.Equal(0, exited.ExitCode);
+        Assert.Equal(SessionState.Stopped, session.State);
+    }
+
+    [Fact]
+    public async Task ReleaseNextOverridesTimingWithoutWallClockDelays()
+    {
+        var session = new MockPtySession(new PtySessionStartRequest
+        {
+            ProjectId = "broker",
+            SessionId = "session-123"
+        });
+
+        session.EnqueueOutput("later", afterTicks: 5);
+        session.EnqueueExit(17, afterTicks: 6);
+
+        _ = await session.ReadEventAsync();
+
+        Assert.True(session.ReleaseNext());
+        Assert.True(session.TryReadEvent(out var output));
+        Assert.Equal("later", output.Content);
+        Assert.Equal(5, session.CurrentTick);
+
+        Assert.True(session.ReleaseNext());
+        Assert.True(session.TryReadEvent(out var exit));
+        Assert.Equal(17, exit.ExitCode);
+        Assert.False(session.ReleaseNext());
+    }
+
+    [Fact]
+    public async Task RecordsInputsAndRejectsWritesAfterExit()
+    {
+        var session = new MockPtySession(new PtySessionStartRequest
+        {
+            ProjectId = "broker",
+            SessionId = "session-123"
+        });
+
+        _ = await session.ReadEventAsync();
+        await session.WriteAsync("status --json\n");
+        session.EnqueueExit(0);
+        session.ReleaseNext();
+        _ = await session.ReadEventAsync();
+
+        Assert.Equal(["status --json\n"], session.WrittenInputs);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => session.WriteAsync("after-exit\n"));
+        Assert.Contains("stopped", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task HonorsCancellationAndTerminationDeterministically()
+    {
+        var session = new MockPtySession(new PtySessionStartRequest
+        {
+            ProjectId = "broker",
+            SessionId = "session-123"
+        });
+
+        _ = await session.ReadEventAsync();
+
+        using var cancellationSource = new CancellationTokenSource();
+        await cancellationSource.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => session.ReadEventAsync(cancellationSource.Token).AsTask());
+
+        await session.TerminateAsync();
+        var exited = await session.ReadEventAsync();
+
+        Assert.Equal(PtySessionEventKind.Exited, exited.Kind);
+        Assert.Null(exited.ExitCode);
+        Assert.Equal(SessionState.Stopped, session.State);
+    }
+
+    [Fact]
+    public async Task HostCanInjectStartFailures()
+    {
+        var host = new MockPtyHost();
+        host.FailNextStart(new InvalidOperationException("boom"));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => host.StartSessionAsync(new PtySessionStartRequest
+        {
+            ProjectId = "broker",
+            SessionId = "session-123"
+        }));
+
+        Assert.Contains("boom", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(host.StartRequests);
+    }
+}

--- a/tests/SquadScout.Broker.Tests/TestDoubles/MockPtyHarnessFixture.cs
+++ b/tests/SquadScout.Broker.Tests/TestDoubles/MockPtyHarnessFixture.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using SquadScout.Broker.Pty;
+using SquadScout.Broker.Sessions;
+using SquadScout.Contracts.Messages;
+using SquadScout.Contracts.Sessions;
+
+namespace SquadScout.Broker.Tests.TestDoubles;
+
+public sealed class MockPtyHarnessFixture
+{
+    private long _nextMessageId = 1;
+
+    public MockPtyHarnessFixture(int replayBufferCapacity = SessionSequencingDefaults.ReplayBufferCapacity)
+    {
+        RelayPublisher = new RecordingRelayPublisher();
+        Orchestrator = new InMemorySessionOrchestrator(RelayPublisher, new SessionSequenceValidator(), replayBufferCapacity);
+        PtyHost = new MockPtyHost();
+    }
+
+    public RecordingRelayPublisher RelayPublisher { get; }
+
+    public InMemorySessionOrchestrator Orchestrator { get; }
+
+    public MockPtyHost PtyHost { get; }
+
+    public SessionDescriptor Session { get; private set; } = default!;
+
+    public MockPtySession PtySession { get; private set; } = default!;
+
+    public async Task<SessionDescriptor> StartAsync(string projectId = "broker", params string[] arguments)
+    {
+        Session = await Orchestrator.StartAsync(new StartSessionCommand
+        {
+            ProjectId = projectId,
+            RequestedBy = "tests",
+            Arguments = arguments
+        });
+
+        PtySession = (MockPtySession)await PtyHost.StartSessionAsync(new PtySessionStartRequest
+        {
+            ProjectId = Session.ProjectId,
+            SessionId = Session.SessionId,
+            Arguments = arguments
+        });
+
+        await PumpAvailableAsync();
+        return Session;
+    }
+
+    public async Task PumpAvailableAsync()
+    {
+        while (PtySession.TryReadEvent(out var @event))
+        {
+            switch (@event.Kind)
+            {
+                case PtySessionEventKind.Started:
+                    await Orchestrator.RecordBrokerMessageAsync(
+                        Session.SessionId,
+                        CreateBrokerCommand(
+                            SessionMessageType.SessionLifecycle,
+                            new SessionLifecyclePayload
+                            {
+                                State = SessionState.Running,
+                                Reason = "pty-started"
+                            },
+                            @event.TimestampUtc));
+                    break;
+
+                case PtySessionEventKind.Output:
+                    await Orchestrator.RecordBrokerMessageAsync(
+                        Session.SessionId,
+                        CreateBrokerCommand(
+                            SessionMessageType.Output,
+                            new OutputChunkPayload
+                            {
+                                Content = @event.Content ?? string.Empty,
+                                IsError = @event.IsError
+                            },
+                            @event.TimestampUtc));
+                    break;
+
+                case PtySessionEventKind.Exited:
+                    await Orchestrator.RecordBrokerMessageAsync(
+                        Session.SessionId,
+                        CreateBrokerCommand(
+                            SessionMessageType.SessionLifecycle,
+                            new SessionLifecyclePayload
+                            {
+                                State = SessionState.Stopped,
+                                Reason = "pty-exited",
+                                ExitCode = @event.ExitCode
+                            },
+                            @event.TimestampUtc));
+                    break;
+            }
+        }
+    }
+
+    public MessageEnvelope<ReplayRequestPayload> CreateReplayRequest(long fromSequenceInclusive, int maximumMessages = 100) =>
+        new()
+        {
+            ProjectId = Session.ProjectId,
+            SessionId = Session.SessionId,
+            Generation = SessionEnvelopeContract.InitialGeneration,
+            MessageType = SessionMessageType.ReplayRequest,
+            Direction = MessageDirection.ClientToBroker,
+            ClientSequence = 1,
+            MessageId = $"client-replay-{_nextMessageId++}",
+            CorrelationId = "corr-replay",
+            Payload = new ReplayRequestPayload
+            {
+                FromSequenceInclusive = fromSequenceInclusive,
+                MaximumMessages = maximumMessages,
+                Reason = ReplayRequestReason.ReconnectResume
+            }
+        };
+
+    private BrokerEnvelopeCommand<TPayload> CreateBrokerCommand<TPayload>(
+        SessionMessageType messageType,
+        TPayload payload,
+        DateTimeOffset timestampUtc) =>
+        new()
+        {
+            MessageType = messageType,
+            MessageId = $"broker-{messageType.ToString().ToLowerInvariant()}-{_nextMessageId++}",
+            CorrelationId = "corr-mock-pty",
+            TimestampUtc = timestampUtc,
+            Payload = payload
+        };
+
+    public static TPayload DeserializePayload<TPayload>(MessageEnvelope<JsonElement> envelope) =>
+        envelope.Payload.Deserialize<TPayload>(SessionMessageSerializer.DefaultOptions)
+            ?? throw new InvalidOperationException($"Unable to deserialize payload as {typeof(TPayload).Name}.");
+}

--- a/tests/SquadScout.Broker.Tests/TestDoubles/RecordingRelayPublisher.cs
+++ b/tests/SquadScout.Broker.Tests/TestDoubles/RecordingRelayPublisher.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using SquadScout.Broker.Relay;
+using SquadScout.Contracts.Messages;
+using SquadScout.Contracts.Sessions;
+
+namespace SquadScout.Broker.Tests.TestDoubles;
+
+public sealed class RecordingRelayPublisher : IRelayPublisher
+{
+    private readonly object _syncRoot = new();
+    private readonly List<MessageEnvelope<JsonElement>> _publishedEnvelopes = [];
+    private readonly List<SessionDescriptor> _startedSessions = [];
+
+    public IReadOnlyList<SessionDescriptor> StartedSessions
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _startedSessions.ToArray();
+            }
+        }
+    }
+
+    public IReadOnlyList<MessageEnvelope<JsonElement>> PublishedEnvelopes
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _publishedEnvelopes.ToArray();
+            }
+        }
+    }
+
+    public Task PublishSessionStartedAsync(SessionDescriptor session, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(session);
+
+        lock (_syncRoot)
+        {
+            _startedSessions.Add(session);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task PublishEnvelopeAsync<TPayload>(MessageEnvelope<TPayload> envelope, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        lock (_syncRoot)
+        {
+            _publishedEnvelopes.Add(ToSnapshot(envelope));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static MessageEnvelope<JsonElement> ToSnapshot<TPayload>(MessageEnvelope<TPayload> envelope) =>
+        new()
+        {
+            ContractVersion = envelope.ContractVersion,
+            ProjectId = envelope.ProjectId,
+            SessionId = envelope.SessionId,
+            Generation = envelope.Generation,
+            MessageType = envelope.MessageType,
+            Direction = envelope.Direction,
+            Sequence = envelope.Sequence,
+            ClientSequence = envelope.ClientSequence,
+            AcknowledgedSequence = envelope.AcknowledgedSequence,
+            TimestampUtc = envelope.TimestampUtc,
+            MessageId = envelope.MessageId,
+            CorrelationId = envelope.CorrelationId,
+            CausationId = envelope.CausationId,
+            Payload = envelope.Payload is JsonElement payload
+                ? payload.Clone()
+                : JsonSerializer.SerializeToElement(envelope.Payload, SessionMessageSerializer.DefaultOptions)
+        };
+}


### PR DESCRIPTION
## Summary
- add a reusable PTY host/session seam and deterministic mock host
- add typed output/lifecycle payloads plus relay capture hooks
- add offline broker tests for chunking, lifecycle, relay ordering, and replay

## Testing
- dotnet build .\SquadScout.slnx -nologo
- dotnet test .\SquadScout.slnx -nologo --no-build

closes #4