### PR TITLE
Implement broker relay pipeline

### DIFF
--- a/.squad/agents/link/history.md
+++ b/.squad/agents/link/history.md
@@ -92,3 +92,10 @@
 - **Acceptance review:** Switch verified all 7 checklist items, confirmed no shell-path creep, confirmed output compatibility with relay layer
 - **Verdict:** APPROVED for merge; unblocks Issue #6 Broker Relay Pipeline
 
+### Issue #6 Broker Relay Pipeline (2026-03-25)
+
+- **Phase 1 relay owner lives above the PTY seam:** `src\SquadScout.Broker\Relay\InMemorySessionRelay.cs` now owns the active PTY session registry, project-root resolution, PTY startup, background envelope pumping, and client-input dispatch so both `MockPtyHost` and `CopilotPtyHost` stay swappable behind `IPtyHost`.
+- **Input sequencing commit rule:** `src\SquadScout.Broker\Sessions\InMemorySessionOrchestrator.cs` now serializes client-envelope acceptance behind a per-session gate and only commits accepted client sequencing after the PTY write callback succeeds; duplicates stay idempotent and do not write twice.
+- **Broker surface now exercises the datapath:** `src\SquadScout.Broker\Program.cs` starts sessions through the relay service and adds `/api/sessions/{sessionId}/input`, while `tests\SquadScout.Broker.Tests\SessionRelayPipelineTests.cs` proves start → input write → output publication → replay using the mock PTY harness.
+- **Validation path:** `dotnet build .\SquadScout.slnx -nologo` and `dotnet test .\SquadScout.slnx -nologo --no-build` both pass after the relay pipeline landed.
+

--- a/src/SquadScout.Broker/Program.cs
+++ b/src/SquadScout.Broker/Program.cs
@@ -3,6 +3,7 @@ using SquadScout.Broker.Pty;
 using SquadScout.Broker.Projects;
 using SquadScout.Broker.Relay;
 using SquadScout.Broker.Sessions;
+using SquadScout.Contracts.Messages;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,6 +16,7 @@ builder.Services.AddSingleton<IProjectCatalog, InMemoryProjectCatalog>();
 builder.Services.AddSingleton<IPtyHost, CopilotPtyHost>();
 builder.Services.AddSingleton<PtySessionEnvelopePump>();
 builder.Services.AddSingleton<IRelayPublisher, NullRelayPublisher>();
+builder.Services.AddSingleton<ISessionRelay, InMemorySessionRelay>();
 builder.Services.AddSingleton<ISequenceValidator, SessionSequenceValidator>();
 builder.Services.AddSingleton<ISessionOrchestrator, InMemorySessionOrchestrator>();
 
@@ -43,16 +45,66 @@ app.MapPost("/api/projects", async (SquadScout.Contracts.Projects.RegisteredProj
     return Results.Accepted($"/api/projects/{project.ProjectId}", project);
 });
 
-app.MapPost("/api/sessions", async (SquadScout.Contracts.Sessions.StartSessionCommand command, ISessionOrchestrator orchestrator, CancellationToken cancellationToken) =>
+app.MapPost("/api/sessions", async (SquadScout.Contracts.Sessions.StartSessionCommand command, ISessionRelay relay, CancellationToken cancellationToken) =>
 {
-    var session = await orchestrator.StartAsync(command, cancellationToken);
-    return Results.Accepted($"/api/sessions/{session.SessionId}", session);
+    try
+    {
+        var session = await relay.StartAsync(command, cancellationToken);
+        return Results.Accepted($"/api/sessions/{session.SessionId}", session);
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { message = ex.Message });
+    }
+    catch (DirectoryNotFoundException ex)
+    {
+        return Results.Problem(statusCode: StatusCodes.Status500InternalServerError, title: "Session start failed", detail: ex.Message);
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.Problem(statusCode: StatusCodes.Status500InternalServerError, title: "Session start failed", detail: ex.Message);
+    }
+    catch (PtySessionStartException ex)
+    {
+        return Results.Problem(statusCode: StatusCodes.Status500InternalServerError, title: "Session start failed", detail: ex.Message);
+    }
 });
 
 app.MapGet("/api/sessions/{sessionId}", async (string sessionId, ISessionOrchestrator orchestrator, CancellationToken cancellationToken) =>
 {
     var session = await orchestrator.GetAsync(sessionId, cancellationToken);
     return session is null ? Results.NotFound() : Results.Ok(session);
+});
+
+app.MapPost("/api/sessions/{sessionId}/input", async (
+    string sessionId,
+    MessageEnvelope<InputChunkPayload> envelope,
+    ISessionRelay relay,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var validation = await relay.RelayInputAsync(sessionId, envelope, cancellationToken);
+        return validation.Status switch
+        {
+            SequenceValidationStatus.Accepted or SequenceValidationStatus.Duplicate => Results.Ok(validation),
+            SequenceValidationStatus.GapDetected or SequenceValidationStatus.StaleGeneration or SequenceValidationStatus.FutureGeneration => Results.Conflict(validation),
+            SequenceValidationStatus.InvalidEnvelope => Results.BadRequest(validation),
+            _ => Results.BadRequest(validation)
+        };
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { message = ex.Message });
+    }
+    catch (KeyNotFoundException ex)
+    {
+        return Results.NotFound(new { message = ex.Message });
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.Conflict(new { message = ex.Message });
+    }
 });
 
 app.Run();

--- a/src/SquadScout.Broker/Projects/IProjectCatalog.cs
+++ b/src/SquadScout.Broker/Projects/IProjectCatalog.cs
@@ -4,6 +4,8 @@ namespace SquadScout.Broker.Projects;
 
 public interface IProjectCatalog
 {
+    Task<RegisteredProject?> GetAsync(string projectId, CancellationToken cancellationToken = default);
+
     Task<IReadOnlyCollection<RegisteredProject>> ListAsync(CancellationToken cancellationToken = default);
 
     Task UpsertAsync(RegisteredProject project, CancellationToken cancellationToken = default);

--- a/src/SquadScout.Broker/Projects/InMemoryProjectCatalog.cs
+++ b/src/SquadScout.Broker/Projects/InMemoryProjectCatalog.cs
@@ -7,8 +7,23 @@ public sealed class InMemoryProjectCatalog : IProjectCatalog
 {
     private readonly ConcurrentDictionary<string, RegisteredProject> _projects = new(StringComparer.OrdinalIgnoreCase);
 
+    public Task<RegisteredProject?> GetAsync(string projectId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(projectId))
+        {
+            throw new ArgumentException("A project id is required.", nameof(projectId));
+        }
+
+        _projects.TryGetValue(projectId, out var project);
+        return Task.FromResult(project);
+    }
+
     public Task<IReadOnlyCollection<RegisteredProject>> ListAsync(CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var projects = _projects.Values
             .OrderBy(project => project.DisplayName, StringComparer.OrdinalIgnoreCase)
             .ToArray();
@@ -18,6 +33,9 @@ public sealed class InMemoryProjectCatalog : IProjectCatalog
 
     public Task UpsertAsync(RegisteredProject project, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(project);
+
         _projects[project.ProjectId] = project;
         return Task.CompletedTask;
     }

--- a/src/SquadScout.Broker/Relay/ISessionRelay.cs
+++ b/src/SquadScout.Broker/Relay/ISessionRelay.cs
@@ -1,0 +1,15 @@
+using SquadScout.Broker.Sessions;
+using SquadScout.Contracts.Messages;
+using SquadScout.Contracts.Sessions;
+
+namespace SquadScout.Broker.Relay;
+
+public interface ISessionRelay
+{
+    Task<SessionDescriptor> StartAsync(StartSessionCommand command, CancellationToken cancellationToken = default);
+
+    Task<SequenceValidationResult> RelayInputAsync(
+        string sessionId,
+        MessageEnvelope<InputChunkPayload> envelope,
+        CancellationToken cancellationToken = default);
+}

--- a/src/SquadScout.Broker/Relay/InMemorySessionRelay.cs
+++ b/src/SquadScout.Broker/Relay/InMemorySessionRelay.cs
@@ -1,0 +1,253 @@
+using System.Collections.Concurrent;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+using SquadScout.Broker.Projects;
+using SquadScout.Broker.Pty;
+using SquadScout.Broker.Sessions;
+using SquadScout.Contracts.Messages;
+using SquadScout.Contracts.Sessions;
+
+namespace SquadScout.Broker.Relay;
+
+public sealed class InMemorySessionRelay : ISessionRelay, IAsyncDisposable
+{
+    private readonly IProjectCatalog _projectCatalog;
+    private readonly ISessionOrchestrator _orchestrator;
+    private readonly IPtyHost _ptyHost;
+    private readonly PtySessionEnvelopePump _ptyPump;
+    private readonly ILogger<InMemorySessionRelay> _logger;
+    private readonly ConcurrentDictionary<string, ActiveRelaySession> _activeSessions = new(StringComparer.OrdinalIgnoreCase);
+    private long _nextMessageId;
+
+    public InMemorySessionRelay(
+        IProjectCatalog projectCatalog,
+        ISessionOrchestrator orchestrator,
+        IPtyHost ptyHost,
+        PtySessionEnvelopePump ptyPump,
+        ILogger<InMemorySessionRelay> logger)
+    {
+        _projectCatalog = projectCatalog ?? throw new ArgumentNullException(nameof(projectCatalog));
+        _orchestrator = orchestrator ?? throw new ArgumentNullException(nameof(orchestrator));
+        _ptyHost = ptyHost ?? throw new ArgumentNullException(nameof(ptyHost));
+        _ptyPump = ptyPump ?? throw new ArgumentNullException(nameof(ptyPump));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<SessionDescriptor> StartAsync(StartSessionCommand command, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(command);
+
+        var session = await _orchestrator.StartAsync(command, cancellationToken).ConfigureAwait(false);
+        IPtySession? ptySession = null;
+
+        try
+        {
+            var request = await CreateStartRequestAsync(session, command, cancellationToken).ConfigureAwait(false);
+            ptySession = await _ptyHost.StartSessionAsync(request, cancellationToken).ConfigureAwait(false);
+
+            await _ptyPump.PumpAvailableAsync(ptySession).ConfigureAwait(false);
+
+            if (ptySession.State == SessionState.Stopped)
+            {
+                await ptySession.DisposeAsync().ConfigureAwait(false);
+                return session with { State = SessionState.Stopped };
+            }
+
+            var activeSession = new ActiveRelaySession(ptySession);
+            if (!_activeSessions.TryAdd(session.SessionId, activeSession))
+            {
+                throw new InvalidOperationException($"An active PTY session already exists for session '{session.SessionId}'.");
+            }
+
+            activeSession.PumpTask = RunPumpLoopAsync(session.SessionId, activeSession);
+            return session with { State = SessionState.Running };
+        }
+        catch (OperationCanceledException)
+        {
+            if (ptySession is not null)
+            {
+                await SafeDisposeAsync(ptySession).ConfigureAwait(false);
+            }
+
+            await TryPublishLifecycleAsync(session.SessionId, SessionState.Stopped, "pty-start-cancelled").ConfigureAwait(false);
+            throw;
+        }
+        catch
+        {
+            if (ptySession is not null)
+            {
+                await SafeDisposeAsync(ptySession).ConfigureAwait(false);
+            }
+
+            await TryPublishLifecycleAsync(session.SessionId, SessionState.Stopped, "pty-start-failed").ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public async Task<SequenceValidationResult> RelayInputAsync(
+        string sessionId,
+        MessageEnvelope<InputChunkPayload> envelope,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(envelope);
+        ArgumentNullException.ThrowIfNull(envelope.Payload);
+
+        if (envelope.MessageType != SessionMessageType.Input)
+        {
+            throw new ArgumentException("Relay input requires an input message envelope.", nameof(envelope));
+        }
+
+        if (envelope.Direction != MessageDirection.ClientToBroker)
+        {
+            throw new ArgumentException("Relay input requires a client-to-broker envelope.", nameof(envelope));
+        }
+
+        var activeSession = await GetRequiredActiveSessionAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        return await _orchestrator.AcceptClientMessageAsync(
+            sessionId,
+            envelope,
+            (acceptedEnvelope, token) => activeSession.PtySession.WriteAsync(acceptedEnvelope.Payload.Content, token),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        var activeSessions = _activeSessions.ToArray();
+        _activeSessions.Clear();
+
+        foreach (var (_, activeSession) in activeSessions)
+        {
+            try
+            {
+                await activeSession.PtySession.TerminateAsync().ConfigureAwait(false);
+                await activeSession.PumpTask.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to dispose relay session {SessionId}.", activeSession.PtySession.SessionId);
+            }
+        }
+    }
+
+    private async Task<PtySessionStartRequest> CreateStartRequestAsync(
+        SessionDescriptor session,
+        StartSessionCommand command,
+        CancellationToken cancellationToken)
+    {
+        var project = await _projectCatalog.GetAsync(session.ProjectId, cancellationToken).ConfigureAwait(false);
+
+        return new PtySessionStartRequest
+        {
+            SessionId = session.SessionId,
+            ProjectId = session.ProjectId,
+            WorkingDirectory = project?.RepositoryRoot ?? string.Empty,
+            Arguments = command.Arguments
+        };
+    }
+
+    private async Task<ActiveRelaySession> GetRequiredActiveSessionAsync(string sessionId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            throw new ArgumentException("A session id is required.", nameof(sessionId));
+        }
+
+        if (_activeSessions.TryGetValue(sessionId, out var activeSession))
+        {
+            return activeSession;
+        }
+
+        var session = await _orchestrator.GetAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        if (session is null)
+        {
+            throw new KeyNotFoundException($"Session '{sessionId}' was not found.");
+        }
+
+        throw new InvalidOperationException($"Session '{sessionId}' does not have an active PTY session.");
+    }
+
+    private async Task RunPumpLoopAsync(string sessionId, ActiveRelaySession activeSession)
+    {
+        try
+        {
+            await _ptyPump.PumpUntilExitAsync(activeSession.PtySession).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "PTY relay pump failed for session {SessionId}.", sessionId);
+
+            try
+            {
+                await activeSession.PtySession.TerminateAsync().ConfigureAwait(false);
+            }
+            catch (Exception terminateEx)
+            {
+                _logger.LogWarning(terminateEx, "PTY termination failed after a relay pump fault for session {SessionId}.", sessionId);
+            }
+
+            if (activeSession.PtySession.State != SessionState.Stopped)
+            {
+                await TryPublishLifecycleAsync(sessionId, SessionState.Stopped, "relay-pump-failed").ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _activeSessions.TryRemove(sessionId, out _);
+            await SafeDisposeAsync(activeSession.PtySession).ConfigureAwait(false);
+        }
+    }
+
+    private async Task TryPublishLifecycleAsync(string sessionId, SessionState state, string reason)
+    {
+        try
+        {
+            await PublishLifecycleAsync(sessionId, state, reason).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to publish relay lifecycle {Reason} for session {SessionId}.", reason, sessionId);
+        }
+    }
+
+    private Task PublishLifecycleAsync(string sessionId, SessionState state, string reason) =>
+        _orchestrator.RecordBrokerMessageAsync(
+            sessionId,
+            new BrokerEnvelopeCommand<SessionLifecyclePayload>
+            {
+                MessageType = SessionMessageType.SessionLifecycle,
+                MessageId = $"relay-{sessionId}-{Interlocked.Increment(ref _nextMessageId)}",
+                CorrelationId = $"pty-session:{sessionId}",
+                TimestampUtc = DateTimeOffset.UtcNow,
+                Payload = new SessionLifecyclePayload
+                {
+                    State = state,
+                    Reason = reason
+                }
+            });
+
+    private async Task SafeDisposeAsync(IPtySession session)
+    {
+        try
+        {
+            await session.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "PTY session disposal failed for session {SessionId}.", session.SessionId);
+        }
+    }
+
+    private sealed class ActiveRelaySession
+    {
+        public ActiveRelaySession(IPtySession ptySession)
+        {
+            PtySession = ptySession;
+        }
+
+        public IPtySession PtySession { get; }
+
+        public Task PumpTask { get; set; } = Task.CompletedTask;
+    }
+}

--- a/src/SquadScout.Broker/Sessions/ISessionOrchestrator.cs
+++ b/src/SquadScout.Broker/Sessions/ISessionOrchestrator.cs
@@ -19,6 +19,12 @@ public interface ISessionOrchestrator
         MessageEnvelope<TPayload> envelope,
         CancellationToken cancellationToken = default);
 
+    Task<SequenceValidationResult> AcceptClientMessageAsync<TPayload>(
+        string sessionId,
+        MessageEnvelope<TPayload> envelope,
+        Func<MessageEnvelope<TPayload>, CancellationToken, Task> onAcceptedAsync,
+        CancellationToken cancellationToken = default);
+
     Task<MessageEnvelope<ReplayResponsePayload>> ReplayAsync(
         string sessionId,
         MessageEnvelope<ReplayRequestPayload> request,

--- a/src/SquadScout.Broker/Sessions/InMemorySessionOrchestrator.cs
+++ b/src/SquadScout.Broker/Sessions/InMemorySessionOrchestrator.cs
@@ -77,23 +77,55 @@ public sealed class InMemorySessionOrchestrator : ISessionOrchestrator
     public Task<SequenceValidationResult> ValidateClientMessageAsync<TPayload>(
         string sessionId,
         MessageEnvelope<TPayload> envelope,
+        CancellationToken cancellationToken = default) =>
+        AcceptClientMessageAsync(
+            sessionId,
+            envelope,
+            static (_, _) => Task.CompletedTask,
+            cancellationToken);
+
+    public async Task<SequenceValidationResult> AcceptClientMessageAsync<TPayload>(
+        string sessionId,
+        MessageEnvelope<TPayload> envelope,
+        Func<MessageEnvelope<TPayload>, CancellationToken, Task> onAcceptedAsync,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ArgumentNullException.ThrowIfNull(envelope);
+        ArgumentNullException.ThrowIfNull(onAcceptedAsync);
 
         var state = GetRequiredSessionState(sessionId);
         EnsureEnvelopeTargetsSession(envelope, state);
-        lock (state.SyncRoot)
-        {
-            var result = _sequenceValidator.Validate(state.CreateSnapshot(), envelope);
-            state.ApplyValidationResult(result);
 
-            return Task.FromResult(result);
+        await state.ClientMessageGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            SequenceValidationResult result;
+            lock (state.SyncRoot)
+            {
+                result = _sequenceValidator.Validate(state.CreateSnapshot(), envelope);
+                if (!result.IsAccepted || result.Status == SequenceValidationStatus.Duplicate)
+                {
+                    state.ApplyValidationResult(result);
+                    return result;
+                }
+            }
+
+            await onAcceptedAsync(envelope, cancellationToken).ConfigureAwait(false);
+
+            lock (state.SyncRoot)
+            {
+                state.ApplyValidationResult(result);
+                return result;
+            }
+        }
+        finally
+        {
+            state.ClientMessageGate.Release();
         }
     }
 
-    public Task<MessageEnvelope<ReplayResponsePayload>> ReplayAsync(
+    public async Task<MessageEnvelope<ReplayResponsePayload>> ReplayAsync(
         string sessionId,
         MessageEnvelope<ReplayRequestPayload> request,
         CancellationToken cancellationToken = default)
@@ -108,20 +140,29 @@ public sealed class InMemorySessionOrchestrator : ISessionOrchestrator
 
         var state = GetRequiredSessionState(sessionId);
         EnsureEnvelopeTargetsSession(request, state);
-        lock (state.SyncRoot)
+
+        await state.ClientMessageGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            if (request.Generation == state.Generation)
+            lock (state.SyncRoot)
             {
-                var validation = _sequenceValidator.Validate(state.CreateSnapshot(), request);
-                if (!validation.IsAccepted)
+                if (request.Generation == state.Generation)
                 {
-                    throw new InvalidOperationException(validation.Reason ?? $"Replay request rejected with {validation.Status}.");
+                    var validation = _sequenceValidator.Validate(state.CreateSnapshot(), request);
+                    if (!validation.IsAccepted)
+                    {
+                        throw new InvalidOperationException(validation.Reason ?? $"Replay request rejected with {validation.Status}.");
+                    }
+
+                    state.ApplyValidationResult(validation);
                 }
 
-                state.ApplyValidationResult(validation);
+                return state.CreateReplayResponse(request);
             }
-
-            return Task.FromResult(state.CreateReplayResponse(request));
+        }
+        finally
+        {
+            state.ClientMessageGate.Release();
         }
     }
 

--- a/src/SquadScout.Broker/Sessions/SessionRuntimeState.cs
+++ b/src/SquadScout.Broker/Sessions/SessionRuntimeState.cs
@@ -18,6 +18,8 @@ internal sealed class SessionRuntimeState
 
     public object SyncRoot { get; } = new();
 
+    public SemaphoreSlim ClientMessageGate { get; } = new(1, 1);
+
     public long Generation { get; private set; } = SessionEnvelopeContract.InitialGeneration;
 
     public long NextBrokerSequence { get; private set; } = 1;

--- a/tests/SquadScout.Broker.Tests/SessionRelayPipelineTests.cs
+++ b/tests/SquadScout.Broker.Tests/SessionRelayPipelineTests.cs
@@ -1,0 +1,254 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using SquadScout.Broker.Projects;
+using SquadScout.Broker.Pty;
+using SquadScout.Broker.Relay;
+using SquadScout.Broker.Sessions;
+using SquadScout.Broker.Tests.TestDoubles;
+using SquadScout.Contracts.Messages;
+using SquadScout.Contracts.Projects;
+using SquadScout.Contracts.Sessions;
+
+namespace SquadScout.Broker.Tests;
+
+public sealed class SessionRelayPipelineTests
+{
+    [Fact]
+    public async Task StartAsyncLaunchesPtyRoutesInputAndPublishesReplayableOutput()
+    {
+        var harness = await CreateHarnessAsync();
+        await using var relay = harness.CreateRelay();
+
+        var session = await relay.StartAsync(new StartSessionCommand
+        {
+            ProjectId = "broker",
+            RequestedBy = "tests",
+            Arguments = ["--project", "broker"]
+        });
+
+        Assert.Equal(SessionState.Running, session.State);
+
+        var startRequest = Assert.Single(harness.PtyHost.StartRequests);
+        Assert.Equal(session.SessionId, startRequest.SessionId);
+        Assert.Equal(session.ProjectId, startRequest.ProjectId);
+        Assert.Equal(@"D:\GitHub\SquadScout-6", startRequest.WorkingDirectory);
+        Assert.Equal(["--project", "broker"], startRequest.Arguments);
+
+        var validation = await relay.RelayInputAsync(session.SessionId, CreateInputEnvelope(session, clientSequence: 1, "status --json\n"));
+        Assert.Equal(SequenceValidationStatus.Accepted, validation.Status);
+
+        var ptySession = harness.PtyHost.GetRequiredSession(session.SessionId);
+        Assert.Equal(["status --json\n"], ptySession.WrittenInputs);
+
+        ptySession.EnqueueOutput("ready", afterTicks: 1);
+        ptySession.EnqueueExit(0, afterTicks: 2);
+        ptySession.ReleaseAll();
+
+        var published = await harness.RelayPublisher.WaitForEnvelopeCountAsync(3);
+
+        Assert.Collection(
+            published.Take(3),
+            message =>
+            {
+                Assert.Equal(1, message.Sequence);
+                Assert.Equal(SessionMessageType.SessionLifecycle, message.MessageType);
+                var payload = MockPtyHarnessFixture.DeserializePayload<SessionLifecyclePayload>(message);
+                Assert.Equal(SessionState.Running, payload.State);
+                Assert.Equal("pty-started", payload.Reason);
+            },
+            message =>
+            {
+                Assert.Equal(2, message.Sequence);
+                Assert.Equal(SessionMessageType.Output, message.MessageType);
+                var payload = MockPtyHarnessFixture.DeserializePayload<OutputChunkPayload>(message);
+                Assert.Equal("ready", payload.Content);
+            },
+            message =>
+            {
+                Assert.Equal(3, message.Sequence);
+                Assert.Equal(SessionMessageType.SessionLifecycle, message.MessageType);
+                var payload = MockPtyHarnessFixture.DeserializePayload<SessionLifecyclePayload>(message);
+                Assert.Equal(SessionState.Stopped, payload.State);
+                Assert.Equal(0, payload.ExitCode);
+                Assert.Equal("pty-exited", payload.Reason);
+            });
+
+        var replay = await harness.Orchestrator.ReplayAsync(session.SessionId, CreateReplayRequest(session, clientSequence: 2, fromSequenceInclusive: 1));
+
+        Assert.Equal(1, replay.Payload.FromSequenceInclusive);
+        Assert.Equal(3, replay.Payload.ToSequenceInclusive);
+        Assert.False(replay.Payload.GapDetected);
+        Assert.Collection(
+            replay.Payload.Messages,
+            message => Assert.Equal(SessionMessageType.SessionLifecycle, message.MessageType),
+            message => Assert.Equal(SessionMessageType.Output, message.MessageType),
+            message => Assert.Equal(SessionMessageType.SessionLifecycle, message.MessageType));
+
+        var descriptor = await harness.Orchestrator.GetAsync(session.SessionId);
+        Assert.NotNull(descriptor);
+        Assert.Equal(SessionState.Stopped, descriptor!.State);
+    }
+
+    [Fact]
+    public async Task RelayInputAsyncDoesNotWriteDuplicateClientMessagesTwice()
+    {
+        var harness = await CreateHarnessAsync();
+        await using var relay = harness.CreateRelay();
+
+        var session = await relay.StartAsync(new StartSessionCommand
+        {
+            ProjectId = "broker",
+            RequestedBy = "tests"
+        });
+
+        var envelope = CreateInputEnvelope(session, clientSequence: 1, "help\n");
+
+        var first = await relay.RelayInputAsync(session.SessionId, envelope);
+        var duplicate = await relay.RelayInputAsync(session.SessionId, envelope with { MessageId = "client-input-duplicate" });
+
+        var ptySession = harness.PtyHost.GetRequiredSession(session.SessionId);
+        Assert.Equal(SequenceValidationStatus.Accepted, first.Status);
+        Assert.Equal(SequenceValidationStatus.Duplicate, duplicate.Status);
+        Assert.Equal(["help\n"], ptySession.WrittenInputs);
+    }
+
+    [Fact]
+    public async Task RelayInputAsyncRejectsInactiveSessionsAfterPtyExit()
+    {
+        var harness = await CreateHarnessAsync();
+        await using var relay = harness.CreateRelay();
+
+        var session = await relay.StartAsync(new StartSessionCommand
+        {
+            ProjectId = "broker",
+            RequestedBy = "tests"
+        });
+
+        var ptySession = harness.PtyHost.GetRequiredSession(session.SessionId);
+        ptySession.EnqueueExit(0);
+        ptySession.ReleaseNext();
+
+        _ = await harness.RelayPublisher.WaitForEnvelopeCountAsync(2);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => relay.RelayInputAsync(
+            session.SessionId,
+            CreateInputEnvelope(session, clientSequence: 1, "after-exit\n")));
+
+        Assert.Contains("active PTY", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task StartAsyncMarksSessionStoppedWhenPtyStartupFails()
+    {
+        var harness = await CreateHarnessAsync();
+        harness.PtyHost.FailNextStart(new InvalidOperationException("boom"));
+        await using var relay = harness.CreateRelay();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => relay.StartAsync(new StartSessionCommand
+        {
+            ProjectId = "broker",
+            RequestedBy = "tests"
+        }));
+
+        var startedSession = Assert.Single(harness.RelayPublisher.StartedSessions);
+        var published = await harness.RelayPublisher.WaitForEnvelopeCountAsync(1);
+        var lifecycle = Assert.Single(published);
+
+        Assert.Equal(SessionMessageType.SessionLifecycle, lifecycle.MessageType);
+        var payload = MockPtyHarnessFixture.DeserializePayload<SessionLifecyclePayload>(lifecycle);
+        Assert.Equal(SessionState.Stopped, payload.State);
+        Assert.Equal("pty-start-failed", payload.Reason);
+
+        var descriptor = await harness.Orchestrator.GetAsync(startedSession.SessionId);
+        Assert.NotNull(descriptor);
+        Assert.Equal(SessionState.Stopped, descriptor!.State);
+    }
+
+    private static async Task<RelayHarness> CreateHarnessAsync()
+    {
+        var catalog = new InMemoryProjectCatalog();
+        await catalog.UpsertAsync(new RegisteredProject
+        {
+            ProjectId = "broker",
+            DisplayName = "Broker",
+            RepositoryRoot = @"D:\GitHub\SquadScout-6"
+        });
+
+        var relayPublisher = new RecordingRelayPublisher();
+        var orchestrator = new InMemorySessionOrchestrator(relayPublisher, new SessionSequenceValidator(), replayBufferCapacity: 8);
+        var ptyHost = new MockPtyHost();
+        return new RelayHarness(catalog, relayPublisher, orchestrator, ptyHost);
+    }
+
+    private static MessageEnvelope<InputChunkPayload> CreateInputEnvelope(
+        SessionDescriptor session,
+        long clientSequence,
+        string content) =>
+        new()
+        {
+            ProjectId = session.ProjectId,
+            SessionId = session.SessionId,
+            Generation = SessionEnvelopeContract.InitialGeneration,
+            MessageType = SessionMessageType.Input,
+            Direction = MessageDirection.ClientToBroker,
+            ClientSequence = clientSequence,
+            MessageId = $"client-input-{clientSequence}",
+            CorrelationId = "corr-input",
+            Payload = new InputChunkPayload
+            {
+                Content = content
+            }
+        };
+
+    private static MessageEnvelope<ReplayRequestPayload> CreateReplayRequest(
+        SessionDescriptor session,
+        long clientSequence,
+        long fromSequenceInclusive) =>
+        new()
+        {
+            ProjectId = session.ProjectId,
+            SessionId = session.SessionId,
+            Generation = SessionEnvelopeContract.InitialGeneration,
+            MessageType = SessionMessageType.ReplayRequest,
+            Direction = MessageDirection.ClientToBroker,
+            ClientSequence = clientSequence,
+            MessageId = $"client-replay-{clientSequence}",
+            CorrelationId = "corr-replay",
+            Payload = new ReplayRequestPayload
+            {
+                FromSequenceInclusive = fromSequenceInclusive,
+                MaximumMessages = 10,
+                Reason = ReplayRequestReason.ReconnectResume
+            }
+        };
+
+    private sealed class RelayHarness
+    {
+        public RelayHarness(
+            InMemoryProjectCatalog projectCatalog,
+            RecordingRelayPublisher relayPublisher,
+            InMemorySessionOrchestrator orchestrator,
+            MockPtyHost ptyHost)
+        {
+            ProjectCatalog = projectCatalog;
+            RelayPublisher = relayPublisher;
+            Orchestrator = orchestrator;
+            PtyHost = ptyHost;
+        }
+
+        public InMemoryProjectCatalog ProjectCatalog { get; }
+
+        public RecordingRelayPublisher RelayPublisher { get; }
+
+        public InMemorySessionOrchestrator Orchestrator { get; }
+
+        public MockPtyHost PtyHost { get; }
+
+        public InMemorySessionRelay CreateRelay() =>
+            new(
+                ProjectCatalog,
+                Orchestrator,
+                PtyHost,
+                new PtySessionEnvelopePump(Orchestrator),
+                NullLogger<InMemorySessionRelay>.Instance);
+    }
+}

--- a/tests/SquadScout.Broker.Tests/TestDoubles/RecordingRelayPublisher.cs
+++ b/tests/SquadScout.Broker.Tests/TestDoubles/RecordingRelayPublisher.cs
@@ -59,6 +59,33 @@ public sealed class RecordingRelayPublisher : IRelayPublisher
         return Task.CompletedTask;
     }
 
+    public async Task<IReadOnlyList<MessageEnvelope<JsonElement>>> WaitForEnvelopeCountAsync(
+        int expectedCount,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (expectedCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(expectedCount), expectedCount, "Expected count must be non-negative.");
+        }
+
+        var deadlineUtc = DateTimeOffset.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+        while (DateTimeOffset.UtcNow <= deadlineUtc)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var envelopes = PublishedEnvelopes;
+            if (envelopes.Count >= expectedCount)
+            {
+                return envelopes;
+            }
+
+            await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException($"Timed out waiting for {expectedCount} published envelope(s).");
+    }
+
     private static MessageEnvelope<JsonElement> ToSnapshot<TPayload>(MessageEnvelope<TPayload> envelope) =>
         new()
         {


### PR DESCRIPTION
## Summary
- add an in-memory session relay that starts PTY sessions, tracks active runtimes, pumps PTY events, and routes client input
- commit client sequencing only after PTY writes succeed, while keeping duplicate inputs idempotent
- expose broker input routing via /api/sessions/{sessionId}/input and cover the Phase 1 datapath with relay pipeline tests

## Validation
- dotnet build .\\SquadScout.slnx -nologo
- dotnet test .\\SquadScout.slnx -nologo --no-build

closes #6