### PR TITLE
Implement issue #8 safety baseline

### DIFF
--- a/src/SquadScout.Broker/Configuration/CopilotPtyHostOptions.cs
+++ b/src/SquadScout.Broker/Configuration/CopilotPtyHostOptions.cs
@@ -1,3 +1,5 @@
+using SquadScout.Contracts.Security;
+
 namespace SquadScout.Broker.Configuration;
 
 public sealed class CopilotPtyHostOptions
@@ -15,6 +17,8 @@ public sealed class CopilotPtyHostOptions
     public int InitialColumns { get; set; } = 120;
 
     public int OutputBufferSize { get; set; } = 1024;
+
+    public int MaxInputCharactersPerWrite { get; set; } = PtyInputSanitizer.DefaultMaxInputCharactersPerWrite;
 
     public Dictionary<string, string> Environment { get; set; } = [];
 }

--- a/src/SquadScout.Broker/Pty/CopilotPtyHost.cs
+++ b/src/SquadScout.Broker/Pty/CopilotPtyHost.cs
@@ -68,6 +68,7 @@ public sealed class CopilotPtyHost : IPtyHost
                 request,
                 connection,
                 Math.Max(1, _options.OutputBufferSize),
+                Math.Max(1, _options.MaxInputCharactersPerWrite),
                 _loggerFactory.CreateLogger<CopilotPtySession>());
         }
         catch (OperationCanceledException)

--- a/src/SquadScout.Broker/Pty/CopilotPtySession.cs
+++ b/src/SquadScout.Broker/Pty/CopilotPtySession.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using Pty.Net;
+using SquadScout.Contracts.Security;
 using SquadScout.Contracts.Sessions;
 
 namespace SquadScout.Broker.Pty;
@@ -12,6 +13,7 @@ public sealed class CopilotPtySession : IPtySession
     private readonly Channel<PtySessionEvent> _events = Channel.CreateUnbounded<PtySessionEvent>();
     private readonly CancellationTokenSource _lifecycleCancellation = new();
     private readonly ILogger<CopilotPtySession> _logger;
+    private readonly int _maxInputCharactersPerWrite;
     private readonly StreamReader _reader;
     private readonly TaskCompletionSource<ProcessExitObservation> _processExit = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly Task _outputPump;
@@ -29,11 +31,13 @@ public sealed class CopilotPtySession : IPtySession
         PtySessionStartRequest request,
         IPtyConnection connection,
         int outputBufferSize,
+        int maxInputCharactersPerWrite,
         ILogger<CopilotPtySession> logger)
     {
         ArgumentNullException.ThrowIfNull(request);
         _connection = connection ?? throw new ArgumentNullException(nameof(connection));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _maxInputCharactersPerWrite = Math.Max(1, maxInputCharactersPerWrite);
 
         SessionId = request.SessionId;
         ProjectId = request.ProjectId;
@@ -73,7 +77,8 @@ public sealed class CopilotPtySession : IPtySession
             }
         }
 
-        var buffer = Encoding.UTF8.GetBytes(input);
+        var sanitizedInput = PtyInputSanitizer.Sanitize(input, _maxInputCharactersPerWrite);
+        var buffer = Encoding.UTF8.GetBytes(sanitizedInput);
         await _connection.WriterStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
         await _connection.WriterStream.FlushAsync(cancellationToken).ConfigureAwait(false);
     }

--- a/src/SquadScout.Broker/Pty/MockPtySession.cs
+++ b/src/SquadScout.Broker/Pty/MockPtySession.cs
@@ -1,4 +1,5 @@
 using System.Threading.Channels;
+using SquadScout.Contracts.Security;
 using SquadScout.Contracts.Sessions;
 
 namespace SquadScout.Broker.Pty;
@@ -125,6 +126,7 @@ public sealed class MockPtySession : IPtySession
     {
         cancellationToken.ThrowIfCancellationRequested();
         ArgumentNullException.ThrowIfNull(input);
+        var sanitizedInput = PtyInputSanitizer.Sanitize(input);
 
         lock (_syncRoot)
         {
@@ -135,7 +137,7 @@ public sealed class MockPtySession : IPtySession
                 throw new InvalidOperationException("Cannot write to a stopped PTY session.");
             }
 
-            _writtenInputs.Add(input);
+            _writtenInputs.Add(sanitizedInput);
         }
 
         return Task.CompletedTask;

--- a/src/SquadScout.Broker/appsettings.json
+++ b/src/SquadScout.Broker/appsettings.json
@@ -7,7 +7,8 @@
     "ExecutablePath": "copilot",
     "InitialRows": 30,
     "InitialColumns": 120,
-    "OutputBufferSize": 1024
+    "OutputBufferSize": 1024,
+    "MaxInputCharactersPerWrite": 4096
   },
   "AzureWebPubSub": {
     "Hub": "squadscout"

--- a/src/SquadScout.Contracts/Messages/InputChunkPayload.cs
+++ b/src/SquadScout.Contracts/Messages/InputChunkPayload.cs
@@ -1,6 +1,11 @@
+using SquadScout.Contracts.Security;
+
 namespace SquadScout.Contracts.Messages;
 
 public sealed record InputChunkPayload
 {
     public string Content { get; init; } = string.Empty;
+
+    public override string ToString() =>
+        $"InputChunkPayload {{ ContentLength = {Content.Length}, DiagnosticPreview = {SecretRedactor.RedactedValue} }}";
 }

--- a/src/SquadScout.Contracts/Messages/MessageEnvelope.cs
+++ b/src/SquadScout.Contracts/Messages/MessageEnvelope.cs
@@ -52,4 +52,9 @@ public sealed record MessageEnvelope<TPayload>
     public string? CausationId { get; init; }
 
     public TPayload Payload { get; init; } = default!;
+
+    public override string ToString() =>
+        $"MessageEnvelope<{typeof(TPayload).Name}> {{ ContractVersion = {ContractVersion}, ProjectId = {ProjectId}, SessionId = {SessionId}, Generation = {Generation}, MessageType = {MessageType}, Direction = {Direction}, Sequence = {FormatNullable(Sequence)}, ClientSequence = {FormatNullable(ClientSequence)}, AcknowledgedSequence = {FormatNullable(AcknowledgedSequence)}, TimestampUtc = {TimestampUtc:O}, MessageId = {MessageId}, CorrelationId = {CorrelationId}, CausationId = {CausationId ?? "<none>"}, PayloadType = {typeof(TPayload).Name} }}";
+
+    private static string FormatNullable(long? value) => value?.ToString() ?? "<none>";
 }

--- a/src/SquadScout.Contracts/Messages/OutputChunkPayload.cs
+++ b/src/SquadScout.Contracts/Messages/OutputChunkPayload.cs
@@ -1,3 +1,5 @@
+using SquadScout.Contracts.Security;
+
 namespace SquadScout.Contracts.Messages;
 
 public sealed record OutputChunkPayload
@@ -5,4 +7,7 @@ public sealed record OutputChunkPayload
     public string Content { get; init; } = string.Empty;
 
     public bool IsError { get; init; }
+
+    public override string ToString() =>
+        $"OutputChunkPayload {{ ContentLength = {Content.Length}, IsError = {IsError}, DiagnosticPreview = {SecretRedactor.RedactedValue} }}";
 }

--- a/src/SquadScout.Contracts/Security/PtyInputSanitizer.cs
+++ b/src/SquadScout.Contracts/Security/PtyInputSanitizer.cs
@@ -1,0 +1,53 @@
+namespace SquadScout.Contracts.Security;
+
+/// <summary>
+/// Applies the day-1 PTY input safety baseline before text crosses the broker → PTY trust boundary.
+/// </summary>
+public static class PtyInputSanitizer
+{
+    public const int DefaultMaxInputCharactersPerWrite = 4096;
+
+    public static string Sanitize(string input, int maxInputCharactersPerWrite = DefaultMaxInputCharactersPerWrite)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        if (maxInputCharactersPerWrite <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxInputCharactersPerWrite),
+                maxInputCharactersPerWrite,
+                "The PTY input limit must be greater than zero.");
+        }
+
+        var normalized = NormalizeLineEndings(input);
+        if (normalized.Length > maxInputCharactersPerWrite)
+        {
+            throw new ArgumentException(
+                $"PTY input exceeded the {maxInputCharactersPerWrite} character safety limit.",
+                nameof(input));
+        }
+
+        for (var index = 0; index < normalized.Length; index++)
+        {
+            var current = normalized[index];
+            if (IsAllowed(current))
+            {
+                continue;
+            }
+
+            throw new ArgumentException(
+                $"PTY input contains an unsupported control character (U+{(int)current:X4}) at index {index}.",
+                nameof(input));
+        }
+
+        return normalized;
+    }
+
+    private static bool IsAllowed(char value) =>
+        !char.IsControl(value) ||
+        value is '\n' or '\t' or '\b' or '\u001B';
+
+    private static string NormalizeLineEndings(string input) =>
+        input.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n');
+}

--- a/src/SquadScout.Contracts/Security/SecretRedactor.cs
+++ b/src/SquadScout.Contracts/Security/SecretRedactor.cs
@@ -1,0 +1,80 @@
+using System.Text.RegularExpressions;
+
+namespace SquadScout.Contracts.Security;
+
+/// <summary>
+/// Redacts common secret and connection-bearing values before they are written to logs or diagnostics.
+/// </summary>
+public static partial class SecretRedactor
+{
+    public const string RedactedValue = "[REDACTED]";
+
+    public static string Redact(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value ?? string.Empty;
+        }
+
+        var redacted = value;
+        redacted = SensitiveKeyValuePattern().Replace(
+            redacted,
+            match => $"{match.Groups["key"].Value}{match.Groups["separator"].Value}{RedactedValue}");
+
+        redacted = AuthorizationHeaderPattern().Replace(
+            redacted,
+            match => $"{match.Groups["scheme"].Value} {RedactedValue}");
+
+        redacted = ConnectionStringSecretPattern().Replace(
+            redacted,
+            match => $"{match.Groups["key"].Value}={RedactedValue}");
+
+        redacted = CredentialedUriPattern().Replace(
+            redacted,
+            match => $"{match.Groups["scheme"].Value}://{RedactedValue}@");
+
+        redacted = SensitiveQueryValuePattern().Replace(
+            redacted,
+            match => $"{match.Groups["prefix"].Value}{RedactedValue}");
+
+        redacted = JwtTokenPattern().Replace(redacted, RedactedValue);
+        redacted = GitHubTokenPattern().Replace(redacted, RedactedValue);
+
+        return redacted;
+    }
+
+    [GeneratedRegex(
+        @"\b(?<key>password|passwd|pwd|token|secret|api[_-]?key|access[_-]?key|client[_-]?secret)\b(?<separator>\s*[:=]\s*)(?<value>""[^""]*""|'[^']*'|[^;\s,]+)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SensitiveKeyValuePattern();
+
+    [GeneratedRegex(
+        @"\b(?<scheme>bearer)\s+(?<token>[A-Za-z0-9._~+/=-]+)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex AuthorizationHeaderPattern();
+
+    [GeneratedRegex(
+        @"\b(?<key>AccessKey|SharedAccessKey|AccountKey)\s*=\s*(?<value>[^;]+)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex ConnectionStringSecretPattern();
+
+    [GeneratedRegex(
+        @"\b(?<scheme>https?|wss?)://(?<userinfo>[^/\s@]+)@",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex CredentialedUriPattern();
+
+    [GeneratedRegex(
+        @"(?<prefix>[?&](?:sig|token|code|access_token|client_secret|api[_-]?key|apikey|password|secret)=)(?<value>[^&#\s]+)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SensitiveQueryValuePattern();
+
+    [GeneratedRegex(
+        @"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex JwtTokenPattern();
+
+    [GeneratedRegex(
+        @"\b(?:gh[pousr]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+)\b",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex GitHubTokenPattern();
+}

--- a/tests/SquadScout.Broker.Tests/SecurityBaselineTests.cs
+++ b/tests/SquadScout.Broker.Tests/SecurityBaselineTests.cs
@@ -1,0 +1,110 @@
+using SquadScout.Broker.Pty;
+using SquadScout.Contracts.Messages;
+using SquadScout.Contracts.Security;
+using SquadScout.Contracts.Sessions;
+
+namespace SquadScout.Broker.Tests;
+
+public sealed class SecurityBaselineTests
+{
+    [Fact]
+    public void PtyInputSanitizerNormalizesLineEndingsAndAllowsTerminalControls()
+    {
+        var sanitized = PtyInputSanitizer.Sanitize("status\r\n\u001B[A\t\b");
+
+        Assert.Equal("status\n\u001B[A\t\b", sanitized);
+    }
+
+    [Fact]
+    public void PtyInputSanitizerRejectsUnsupportedControls()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => PtyInputSanitizer.Sanitize("hello\0world"));
+
+        Assert.Contains("U+0000", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void PtyInputSanitizerRejectsOversizedWrites()
+    {
+        var oversized = new string('a', PtyInputSanitizer.DefaultMaxInputCharactersPerWrite + 1);
+
+        var exception = Assert.Throws<ArgumentException>(() => PtyInputSanitizer.Sanitize(oversized));
+
+        Assert.Contains("safety limit", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task MockPtySessionStoresSanitizedInput()
+    {
+        var session = new MockPtySession(new PtySessionStartRequest
+        {
+            ProjectId = "broker",
+            SessionId = "session-123"
+        });
+
+        _ = await session.ReadEventAsync();
+        await session.WriteAsync("status\r\n");
+
+        Assert.Equal(["status\n"], session.WrittenInputs);
+    }
+
+    [Fact]
+    public void SecretRedactorRedactsSecretsAndConnectionDetails()
+    {
+        const string sample = "password=swordfish Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature https://user:pass@example.com/path?sig=abc&token=def AccessKey=top-secret ghp_1234567890abcdef";
+
+        var redacted = SecretRedactor.Redact(sample);
+
+        Assert.DoesNotContain("swordfish", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("user:pass", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("abc", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("def", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("top-secret", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("ghp_1234567890abcdef", redacted, StringComparison.Ordinal);
+        Assert.Contains("password=[REDACTED]", redacted, StringComparison.Ordinal);
+        Assert.Contains("Bearer [REDACTED]", redacted, StringComparison.Ordinal);
+        Assert.Contains("https://[REDACTED]@example.com/path?sig=[REDACTED]&token=[REDACTED]", redacted, StringComparison.Ordinal);
+        Assert.Contains("AccessKey=[REDACTED]", redacted, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SecretRedactorLeavesOrdinaryTextAlone()
+    {
+        const string sample = "dotnet test --filter Replay";
+
+        Assert.Equal(sample, SecretRedactor.Redact(sample));
+    }
+
+    [Fact]
+    public void SensitivePayloadsAndEnvelopesDoNotExposeContentInToString()
+    {
+        var payload = new InputChunkPayload
+        {
+            Content = "password=swordfish"
+        };
+
+        var outputPayload = new OutputChunkPayload
+        {
+            Content = "ghp_1234567890abcdef",
+            IsError = true
+        };
+
+        var envelope = new MessageEnvelope<InputChunkPayload>
+        {
+            ProjectId = "broker",
+            SessionId = "session-123",
+            MessageType = SessionMessageType.Input,
+            Direction = MessageDirection.ClientToBroker,
+            MessageId = "msg-123",
+            CorrelationId = "corr-123",
+            Payload = payload
+        };
+
+        Assert.DoesNotContain("swordfish", payload.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("ghp_1234567890abcdef", outputPayload.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("swordfish", envelope.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("password=", envelope.ToString(), StringComparison.Ordinal);
+        Assert.Contains("PayloadType = InputChunkPayload", envelope.ToString(), StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize outbound PTY input before it crosses the broker → PTY boundary
- add shared secret redaction helpers and safe contract string representations for diagnostics
- cover the new security baseline with broker tests

## Validation
- dotnet build .\SquadScout.slnx -nologo
- dotnet test .\SquadScout.slnx -nologo --no-build

closes #8