### PR TITLE
Harden negotiate token validation

### DIFF
--- a/.squad/agents/morpheus/history.md
+++ b/.squad/agents/morpheus/history.md
@@ -100,3 +100,11 @@
 
 **Impact:** Issue #3 remains unmerged; Phase 2 grain activation is blocked. No implementation bug found; coverage is the sole blocker. Morpheus is resting during Link's correction iteration.
 
+### Issue #12 Token Validation & Session Claims Hardening (2026-03-25)
+
+- **Easy Auth headers are only trustworthy inside the Azure Function boundary.** Local or non-Azure requests must not be allowed to self-assert `x-ms-client-principal*` headers; use the localhost development identity path instead.
+- **Header/payload consistency is the tamper check worth preserving.** When Easy Auth provides both direct headers and the base64 principal payload, negotiate should reject mismatched principal/provider data instead of silently preferring one source.
+- **Session scope belongs in the issued connection identity, not just the requested group name.** Encoding `{participantKind, projectId, sessionId, optional brokerId, principalId}` into the PubSub `userId` narrows replay/overreach blast radius and gives downstream components a stable authorization breadcrumb.
+- **Client tokens should not self-select broker affinity before routing exists.** Rejecting `brokerId` on client negotiate requests prevents callers from minting narrower-but-unvetted subgroup identities ahead of issue #14.
+- **Negotiate responses should stay minimal.** Echoing internal roles or Entra identity metadata back to the caller was unnecessary for current clients and widened the contract surface without adding security value.
+

--- a/src/SquadScout.Contracts/Realtime/PubSubNegotiateRequestValidator.cs
+++ b/src/SquadScout.Contracts/Realtime/PubSubNegotiateRequestValidator.cs
@@ -1,0 +1,29 @@
+namespace SquadScout.Contracts.Realtime;
+
+public static class PubSubNegotiateRequestValidator
+{
+    public static bool TryValidate(PubSubNegotiateRequest request, out string validationError)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!Enum.IsDefined(request.ParticipantKind))
+        {
+            validationError = "participantKind must be either 'client' or 'broker'.";
+            return false;
+        }
+
+        if (request.ParticipantKind == PubSubParticipantKind.Client &&
+            !string.IsNullOrWhiteSpace(request.BrokerId))
+        {
+            validationError = "brokerId is only valid for broker-scoped negotiate requests.";
+            return false;
+        }
+
+        return SessionGroupName.TryCreate(
+            request.ProjectId,
+            request.SessionId,
+            request.BrokerId,
+            out _,
+            out validationError);
+    }
+}

--- a/src/SquadScout.Contracts/Realtime/PubSubNegotiateResponse.cs
+++ b/src/SquadScout.Contracts/Realtime/PubSubNegotiateResponse.cs
@@ -18,18 +18,6 @@ public sealed record PubSubNegotiateResponse
 
     public string SessionGroup { get; init; } = string.Empty;
 
-    public string PrincipalId { get; init; } = string.Empty;
-
-    public string DisplayName { get; init; } = string.Empty;
-
-    public string IdentityProvider { get; init; } = string.Empty;
-
-    public bool IsDevelopmentIdentity { get; init; }
-
-    public string[] Roles { get; init; } = [];
-
-    public string[] AutoJoinGroups { get; init; } = [];
-
     public DateTimeOffset ExpiresAtUtc { get; init; }
 
     public DateTimeOffset RefreshAtUtc { get; init; }

--- a/src/SquadScout.Functions/NegotiateFunction.cs
+++ b/src/SquadScout.Functions/NegotiateFunction.cs
@@ -47,7 +47,7 @@ public sealed class NegotiateFunction
             return await WriteErrorAsync(request, HttpStatusCode.BadRequest, "The negotiate request body is required.", cancellationToken);
         }
 
-        if (!TryValidateRequest(negotiateRequest, out var validationError))
+        if (!PubSubNegotiateRequestValidator.TryValidate(negotiateRequest, out var validationError))
         {
             return await WriteErrorAsync(request, HttpStatusCode.BadRequest, validationError, cancellationToken);
         }
@@ -62,12 +62,13 @@ public sealed class NegotiateFunction
         {
             var response = await _negotiationService.NegotiateAsync(negotiateRequest, identity, cancellationToken);
             _logger.LogInformation(
-                "Issued Web PubSub access for {ParticipantKind} on {ProjectId}/{SessionId} with group {SessionGroup}. Development identity: {IsDevelopmentIdentity}.",
+                "Issued Web PubSub access for {ParticipantKind} on {ProjectId}/{SessionId} with group {SessionGroup} for {UserId}. Development identity: {IsDevelopmentIdentity}.",
                 response.ParticipantKind,
                 response.ProjectId,
                 response.SessionId,
                 response.SessionGroup,
-                response.IsDevelopmentIdentity);
+                response.UserId,
+                identity.IsDevelopment);
 
             var httpResponse = request.CreateResponse(HttpStatusCode.OK);
             await httpResponse.WriteAsJsonAsync(response, cancellationToken);
@@ -91,17 +92,6 @@ public sealed class NegotiateFunction
                 "Azure Web PubSub token issuance failed. Check service configuration and permissions.",
                 cancellationToken);
         }
-    }
-
-    private static bool TryValidateRequest(PubSubNegotiateRequest request, out string validationError)
-    {
-        if (!SessionGroupName.TryCreate(request.ProjectId, request.SessionId, request.BrokerId, out _, out validationError))
-        {
-            return false;
-        }
-
-        validationError = string.Empty;
-        return true;
     }
 
     private static async Task<HttpResponseData> WriteErrorAsync(

--- a/src/SquadScout.Functions/Negotiation/NegotiationIdentity.cs
+++ b/src/SquadScout.Functions/Negotiation/NegotiationIdentity.cs
@@ -13,17 +13,74 @@ public sealed partial record NegotiationIdentity
 
     public bool IsDevelopment { get; init; }
 
-    public string CreateConnectionUserId(PubSubParticipantKind participantKind, string? brokerId = null)
+    public string CreateConnectionUserId(
+        PubSubParticipantKind participantKind,
+        string projectId,
+        string sessionId,
+        string? brokerId = null)
     {
-        var prefix = participantKind == PubSubParticipantKind.Broker ? "broker" : "client";
-        var segments = new List<string> { prefix, SanitizeSegment(PrincipalId) };
+        if (!Enum.IsDefined(participantKind))
+        {
+            throw new ArgumentOutOfRangeException(nameof(participantKind), participantKind, "participantKind must be either Client or Broker.");
+        }
 
-        if (participantKind == PubSubParticipantKind.Broker && !string.IsNullOrWhiteSpace(brokerId))
+        var prefix = participantKind == PubSubParticipantKind.Broker ? "broker" : "client";
+        var segments = new List<string>
+        {
+            prefix,
+            SanitizeSegment(projectId),
+            SanitizeSegment(sessionId)
+        };
+
+        if (!string.IsNullOrWhiteSpace(brokerId))
         {
             segments.Add(SanitizeSegment(brokerId));
         }
 
+        segments.Add(SanitizeSegment(PrincipalId));
         return string.Join(':', segments);
+    }
+
+    public bool MatchesAuthenticatedPrincipal(NegotiationIdentity other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        return string.Equals(PrincipalId, other.PrincipalId, StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(IdentityProvider, other.IdentityProvider, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool TryValidateTrustedIdentity(
+        string? principalId,
+        string? identityProvider,
+        out string validationError)
+    {
+        if (!TryValidateRequiredSegment(principalId, "principalId", out validationError) ||
+            !TryValidateRequiredSegment(identityProvider, "identityProvider", out validationError))
+        {
+            return false;
+        }
+
+        validationError = string.Empty;
+        return true;
+    }
+
+    private static bool TryValidateRequiredSegment(string? value, string parameterName, out string validationError)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            validationError = $"A non-empty {parameterName} is required.";
+            return false;
+        }
+
+        if (!TrustedIdentitySegmentPattern().IsMatch(value.Trim()))
+        {
+            validationError =
+                $"{parameterName} may only contain letters, numbers, '.', '_' or '-', and must start with an alphanumeric character.";
+            return false;
+        }
+
+        validationError = string.Empty;
+        return true;
     }
 
     private static string SanitizeSegment(string value)
@@ -39,4 +96,7 @@ public sealed partial record NegotiationIdentity
 
     [GeneratedRegex("[^A-Za-z0-9._-]+", RegexOptions.CultureInvariant)]
     private static partial Regex UnsafeUserIdSegmentPattern();
+
+    [GeneratedRegex("^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$", RegexOptions.CultureInvariant)]
+    private static partial Regex TrustedIdentitySegmentPattern();
 }

--- a/src/SquadScout.Functions/Negotiation/NegotiationIdentityResolver.cs
+++ b/src/SquadScout.Functions/Negotiation/NegotiationIdentityResolver.cs
@@ -33,16 +33,37 @@ public sealed class NegotiationIdentityResolver
         out HttpStatusCode failureStatus,
         out string failureMessage)
     {
-        if (TryResolveEasyAuthIdentity(headers, out identity))
+        if (HasEasyAuthHeaders(headers))
         {
-            failureStatus = HttpStatusCode.OK;
-            failureMessage = string.Empty;
-            return true;
+            if (!CanTrustEasyAuthBoundary())
+            {
+                identity = new NegotiationIdentity();
+                failureStatus = HttpStatusCode.Unauthorized;
+                failureMessage = "Easy Auth identity headers are only trusted inside the Azure Functions host boundary. Use the localhost development identity when running locally.";
+                return false;
+            }
+
+            if (TryResolveEasyAuthIdentity(headers, out identity, out failureMessage))
+            {
+                failureStatus = HttpStatusCode.OK;
+                failureMessage = string.Empty;
+                return true;
+            }
+
+            failureStatus = HttpStatusCode.Unauthorized;
+            return false;
         }
 
         if (CanUseLocalDevelopmentIdentity(requestUri))
         {
             identity = ResolveLocalDevelopmentIdentity(headers);
+            if (!NegotiationIdentity.TryValidateTrustedIdentity(identity.PrincipalId, identity.IdentityProvider, out failureMessage))
+            {
+                identity = new NegotiationIdentity();
+                failureStatus = HttpStatusCode.Unauthorized;
+                return false;
+            }
+
             failureStatus = HttpStatusCode.OK;
             failureMessage = string.Empty;
             return true;
@@ -66,10 +87,7 @@ public sealed class NegotiationIdentityResolver
             return false;
         }
 
-        return requestUri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
-               requestUri.Host.Equals("127.0.0.1", StringComparison.OrdinalIgnoreCase) ||
-               requestUri.Host.Equals("[::1]", StringComparison.OrdinalIgnoreCase) ||
-               requestUri.Host.Equals("::1", StringComparison.OrdinalIgnoreCase);
+        return requestUri.IsLoopback;
     }
 
     private NegotiationIdentity ResolveLocalDevelopmentIdentity(HttpHeadersCollection headers)
@@ -86,89 +104,130 @@ public sealed class NegotiationIdentityResolver
         };
     }
 
-    private static bool TryResolveEasyAuthIdentity(HttpHeadersCollection headers, out NegotiationIdentity identity)
+    private static bool TryResolveEasyAuthIdentity(
+        HttpHeadersCollection headers,
+        out NegotiationIdentity identity,
+        out string validationError)
     {
         var principalId = GetHeaderValue(headers, ClientPrincipalIdHeaderName);
         var displayName = GetHeaderValue(headers, ClientPrincipalNameHeaderName);
         var identityProvider = GetHeaderValue(headers, ClientPrincipalIdentityProviderHeaderName);
+        var principalHeader = GetHeaderValue(headers, ClientPrincipalHeaderName);
+        NegotiationIdentity? payloadIdentity = null;
 
-        if (string.IsNullOrWhiteSpace(principalId) &&
-            TryReadPrincipalPayload(headers, out var payloadIdentity))
+        if (!string.IsNullOrWhiteSpace(principalHeader) &&
+            !TryReadPrincipalPayload(principalHeader, out payloadIdentity, out validationError))
         {
-            identity = payloadIdentity;
-            return true;
+            identity = new NegotiationIdentity();
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(principalId) && payloadIdentity is null)
+        {
+            identity = new NegotiationIdentity();
+            validationError = "The Easy Auth identity boundary did not include a principal identifier.";
+            return false;
         }
 
         if (string.IsNullOrWhiteSpace(principalId))
         {
-            identity = new NegotiationIdentity();
-            return false;
+            identity = payloadIdentity!;
+            return NegotiationIdentity.TryValidateTrustedIdentity(identity.PrincipalId, identity.IdentityProvider, out validationError);
         }
 
         identity = new NegotiationIdentity
         {
-            PrincipalId = principalId,
-            DisplayName = string.IsNullOrWhiteSpace(displayName) ? principalId : displayName,
-            IdentityProvider = string.IsNullOrWhiteSpace(identityProvider) ? "aad" : identityProvider,
+            PrincipalId = principalId.Trim(),
+            DisplayName = string.IsNullOrWhiteSpace(displayName) ? principalId.Trim() : displayName.Trim(),
+            IdentityProvider = string.IsNullOrWhiteSpace(identityProvider)
+                ? payloadIdentity?.IdentityProvider ?? "aad"
+                : identityProvider.Trim(),
             IsDevelopment = false
         };
 
-        return true;
-    }
-
-    private static bool TryReadPrincipalPayload(HttpHeadersCollection headers, out NegotiationIdentity identity)
-    {
-        var principalHeader = GetHeaderValue(headers, ClientPrincipalHeaderName);
-        if (string.IsNullOrWhiteSpace(principalHeader))
+        if (!NegotiationIdentity.TryValidateTrustedIdentity(identity.PrincipalId, identity.IdentityProvider, out validationError))
         {
             identity = new NegotiationIdentity();
             return false;
         }
 
+        if (payloadIdentity is not null && !identity.MatchesAuthenticatedPrincipal(payloadIdentity))
+        {
+            identity = new NegotiationIdentity();
+            validationError = "Easy Auth identity headers did not match the authenticated principal payload.";
+            return false;
+        }
+
+        validationError = string.Empty;
+        return true;
+    }
+
+    private static bool TryReadPrincipalPayload(
+        string principalHeader,
+        out NegotiationIdentity identity,
+        out string validationError)
+    {
         try
         {
             var json = Encoding.UTF8.GetString(Convert.FromBase64String(NormalizeBase64(principalHeader)));
             var payload = JsonSerializer.Deserialize<ClientPrincipalPayload>(json, PrincipalOptions);
-            if (payload?.Claims is null)
+            if (payload is null)
             {
                 identity = new NegotiationIdentity();
+                validationError = "The Easy Auth principal payload was missing required claims.";
                 return false;
             }
 
-            var principalId = GetClaimValue(payload.Claims, "http://schemas.microsoft.com/identity/claims/objectidentifier")
+            var principalId = payload.UserId
+                ?? GetClaimValue(payload.Claims, "http://schemas.microsoft.com/identity/claims/objectidentifier")
                 ?? GetClaimValue(payload.Claims, "oid")
+                ?? GetClaimValue(payload.Claims, "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")
                 ?? GetClaimValue(payload.Claims, "sub");
 
             if (string.IsNullOrWhiteSpace(principalId))
             {
                 identity = new NegotiationIdentity();
+                validationError = "The Easy Auth principal payload did not include a supported Entra principal identifier.";
                 return false;
             }
 
             identity = new NegotiationIdentity
             {
-                PrincipalId = principalId,
+                PrincipalId = principalId.Trim(),
                 DisplayName = GetClaimValue(payload.Claims, "name")
                     ?? GetClaimValue(payload.Claims, "preferred_username")
-                    ?? principalId,
-                IdentityProvider = GetClaimValue(payload.Claims, "http://schemas.microsoft.com/identity/claims/identityprovider")
+                    ?? principalId.Trim(),
+                IdentityProvider = payload.IdentityProvider
+                    ?? payload.AuthenticationType
+                    ?? GetClaimValue(payload.Claims, "http://schemas.microsoft.com/identity/claims/identityprovider")
                     ?? "aad",
                 IsDevelopment = false
             };
 
-            return true;
+            return NegotiationIdentity.TryValidateTrustedIdentity(identity.PrincipalId, identity.IdentityProvider, out validationError);
         }
         catch (FormatException)
         {
             identity = new NegotiationIdentity();
+            validationError = "The Easy Auth principal payload was not valid base64.";
             return false;
         }
         catch (JsonException)
         {
             identity = new NegotiationIdentity();
+            validationError = "The Easy Auth principal payload was not valid JSON.";
             return false;
         }
     }
+
+    private static bool HasEasyAuthHeaders(HttpHeadersCollection headers) =>
+        headers.Contains(ClientPrincipalHeaderName) ||
+        headers.Contains(ClientPrincipalIdHeaderName) ||
+        headers.Contains(ClientPrincipalNameHeaderName) ||
+        headers.Contains(ClientPrincipalIdentityProviderHeaderName);
+
+    private static bool CanTrustEasyAuthBoundary() =>
+        !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID"));
 
     private static string? GetClaimValue(IReadOnlyCollection<ClientPrincipalClaim> claims, string type) =>
         claims.FirstOrDefault(claim =>
@@ -192,6 +251,15 @@ public sealed class NegotiationIdentityResolver
 
     private sealed record ClientPrincipalPayload
     {
+        [JsonPropertyName("auth_typ")]
+        public string? AuthenticationType { get; init; }
+
+        [JsonPropertyName("identityProvider")]
+        public string? IdentityProvider { get; init; }
+
+        [JsonPropertyName("userId")]
+        public string? UserId { get; init; }
+
         public IReadOnlyCollection<ClientPrincipalClaim> Claims { get; init; } = [];
     }
 

--- a/src/SquadScout.Functions/Negotiation/WebPubSubNegotiationService.cs
+++ b/src/SquadScout.Functions/Negotiation/WebPubSubNegotiationService.cs
@@ -31,7 +31,11 @@ public sealed class WebPubSubNegotiationService
         var refreshAt = expiresAt - CalculateRefreshLeadTime(TimeSpan.FromMinutes(_options.TokenLifetimeMinutes));
         var roles = CreateScopedRoles(sessionGroup);
         var autoJoinGroups = new[] { sessionGroup };
-        var userId = identity.CreateConnectionUserId(request.ParticipantKind, request.BrokerId);
+        var userId = identity.CreateConnectionUserId(
+            request.ParticipantKind,
+            request.ProjectId,
+            request.SessionId,
+            request.BrokerId);
         var accessUri = await _accessUriClient.GetClientAccessUriAsync(
             expiresAt,
             userId,
@@ -49,12 +53,6 @@ public sealed class WebPubSubNegotiationService
             ParticipantKind = request.ParticipantKind,
             BrokerId = request.BrokerId,
             SessionGroup = sessionGroup,
-            PrincipalId = identity.PrincipalId,
-            DisplayName = identity.DisplayName,
-            IdentityProvider = identity.IdentityProvider,
-            IsDevelopmentIdentity = identity.IsDevelopment,
-            Roles = roles,
-            AutoJoinGroups = autoJoinGroups,
             ExpiresAtUtc = expiresAt,
             RefreshAtUtc = refreshAt
         };

--- a/tests/SquadScout.Broker.Tests/PubSubNegotiateEndpointTests.cs
+++ b/tests/SquadScout.Broker.Tests/PubSubNegotiateEndpointTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Text;
+using System.Text.Json;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Options;
 using SquadScout.Contracts.Realtime;
@@ -9,6 +11,9 @@ namespace SquadScout.Broker.Tests;
 
 public sealed class PubSubNegotiateEndpointTests
 {
+    private const string WebsiteInstanceIdEnvironmentVariable = "WEBSITE_INSTANCE_ID";
+    private static readonly object EnvironmentVariableSync = new();
+
     [Fact]
     public void SessionGroupNameBuildsBaseAndBrokerScopedGroups()
     {
@@ -36,15 +41,14 @@ public sealed class PubSubNegotiateEndpointTests
         {
             { "x-ms-client-principal-id", "entra-user-42" },
             { "x-ms-client-principal-name", "Ryan Graham" },
-            { "x-ms-client-principal-idp", "aad" }
+            { "x-ms-client-principal-idp", "aad" },
+            { "x-ms-client-principal", CreatePrincipalPayload("entra-user-42", "aad") }
         };
 
-        var success = resolver.TryResolve(
+        var (success, identity, statusCode, failureMessage) = ResolveInTrustedFunctionBoundary(
+            resolver,
             new Uri("https://squadscout.azurewebsites.net/api/negotiate"),
-            headers,
-            out var identity,
-            out var statusCode,
-            out var failureMessage);
+            headers);
 
         Assert.True(success);
         Assert.Equal(HttpStatusCode.OK, statusCode);
@@ -53,6 +57,28 @@ public sealed class PubSubNegotiateEndpointTests
         Assert.Equal("Ryan Graham", identity.DisplayName);
         Assert.Equal("aad", identity.IdentityProvider);
         Assert.False(identity.IsDevelopment);
+    }
+
+    [Fact]
+    public void IdentityResolverRejectsEasyAuthHeadersOutsideTrustedFunctionBoundary()
+    {
+        var resolver = CreateIdentityResolver(new FunctionsHostOptions());
+        var headers = new HttpHeadersCollection
+        {
+            { "x-ms-client-principal-id", "entra-user-42" },
+            { "x-ms-client-principal-idp", "aad" }
+        };
+
+        var success = resolver.TryResolve(
+            new Uri("http://localhost:7071/api/negotiate"),
+            headers,
+            out _,
+            out var statusCode,
+            out var failureMessage);
+
+        Assert.False(success);
+        Assert.Equal(HttpStatusCode.Unauthorized, statusCode);
+        Assert.Contains("only trusted", failureMessage, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -117,22 +143,20 @@ public sealed class PubSubNegotiateEndpointTests
             CancellationToken.None);
 
         Assert.Equal("session:proj-01:session-abc:broker-west", response.SessionGroup);
-        Assert.Equal("broker:entra-user-42:broker-west", response.UserId);
-        Assert.Equal(response.SessionGroup, Assert.Single(response.AutoJoinGroups));
+        Assert.Equal("broker:proj-01:session-abc:broker-west:entra-user-42", response.UserId);
+        Assert.Equal(response.SessionGroup, Assert.Single(accessUriClient.Groups));
         Assert.Equal(
             new[]
             {
                 "webpubsub.joinLeaveGroup.session:proj-01:session-abc:broker-west",
                 "webpubsub.sendToGroup.session:proj-01:session-abc:broker-west"
             },
-            response.Roles);
+            accessUriClient.Roles);
         Assert.Equal(new Uri("wss://example.webpubsub.azure.com/client/hubs/squadscout?access_token=test").ToString(), response.Url);
         Assert.Equal(issuedAt.AddMinutes(60), response.ExpiresAtUtc);
         Assert.Equal(issuedAt.AddMinutes(50), response.RefreshAtUtc);
         Assert.Equal(response.ExpiresAtUtc, accessUriClient.ExpiresAtUtc);
         Assert.Equal(response.UserId, accessUriClient.UserId);
-        Assert.Equal(response.Roles, accessUriClient.Roles);
-        Assert.Equal(response.AutoJoinGroups, accessUriClient.Groups);
     }
 
     [Fact]
@@ -165,15 +189,15 @@ public sealed class PubSubNegotiateEndpointTests
             CancellationToken.None);
 
         Assert.Equal("session:proj-01:session-abc", response.SessionGroup);
-        Assert.Equal("broker:entra-user-42", response.UserId);
-        Assert.Equal(new[] { response.SessionGroup }, response.AutoJoinGroups);
+        Assert.Equal("broker:proj-01:session-abc:entra-user-42", response.UserId);
+        Assert.Equal(new[] { response.SessionGroup }, accessUriClient.Groups);
         Assert.Equal(
             new[]
             {
                 "webpubsub.joinLeaveGroup.session:proj-01:session-abc",
                 "webpubsub.sendToGroup.session:proj-01:session-abc"
             },
-            response.Roles);
+            accessUriClient.Roles);
     }
 
     [Fact]
@@ -208,6 +232,7 @@ public sealed class PubSubNegotiateEndpointTests
 
         Assert.Equal(issuedAt.AddMinutes(1), response.ExpiresAtUtc);
         Assert.Equal(issuedAt.AddSeconds(30), response.RefreshAtUtc);
+        Assert.Equal("client:proj-01:session-abc:entra-user-42", response.UserId);
     }
 
     [Fact]
@@ -230,8 +255,153 @@ public sealed class PubSubNegotiateEndpointTests
         Assert.Contains("localhost", failureMessage, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void IdentityResolverRejectsMismatchedEasyAuthPayload()
+    {
+        var resolver = CreateIdentityResolver(new FunctionsHostOptions());
+        var headers = new HttpHeadersCollection
+        {
+            { "x-ms-client-principal-id", "entra-user-42" },
+            { "x-ms-client-principal-idp", "aad" },
+            { "x-ms-client-principal", CreatePrincipalPayload("different-user", "aad") }
+        };
+
+        var (success, _, statusCode, failureMessage) = ResolveInTrustedFunctionBoundary(
+            resolver,
+            new Uri("https://squadscout.azurewebsites.net/api/negotiate"),
+            headers);
+
+        Assert.False(success);
+        Assert.Equal(HttpStatusCode.Unauthorized, statusCode);
+        Assert.Contains("did not match", failureMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void IdentityResolverRejectsUnsafePrincipalIdentifiers()
+    {
+        var resolver = CreateIdentityResolver(new FunctionsHostOptions());
+        var headers = new HttpHeadersCollection
+        {
+            { "x-ms-client-principal-id", "entra:user:42" },
+            { "x-ms-client-principal-idp", "aad" }
+        };
+
+        var (success, _, statusCode, failureMessage) = ResolveInTrustedFunctionBoundary(
+            resolver,
+            new Uri("https://squadscout.azurewebsites.net/api/negotiate"),
+            headers);
+
+        Assert.False(success);
+        Assert.Equal(HttpStatusCode.Unauthorized, statusCode);
+        Assert.Contains("principalId", failureMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NegotiateRequestValidatorRejectsBrokerScopedClientRequests()
+    {
+        var valid = PubSubNegotiateRequestValidator.TryValidate(
+            new PubSubNegotiateRequest
+            {
+                ProjectId = "proj-01",
+                SessionId = "session-abc",
+                ParticipantKind = PubSubParticipantKind.Client,
+                BrokerId = "broker-west"
+            },
+            out var validationError);
+
+        Assert.False(valid);
+        Assert.Contains("brokerId", validationError, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NegotiateRequestValidatorRejectsUnknownParticipantKinds()
+    {
+        var valid = PubSubNegotiateRequestValidator.TryValidate(
+            new PubSubNegotiateRequest
+            {
+                ProjectId = "proj-01",
+                SessionId = "session-abc",
+                ParticipantKind = (PubSubParticipantKind)999
+            },
+            out var validationError);
+
+        Assert.False(valid);
+        Assert.Contains("participantKind", validationError, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConnectionUserIdRejectsUnknownParticipantKinds()
+    {
+        var identity = new NegotiationIdentity
+        {
+            PrincipalId = "entra-user-42",
+            IdentityProvider = "aad"
+        };
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            identity.CreateConnectionUserId((PubSubParticipantKind)999, "proj-01", "session-abc"));
+
+        Assert.Contains("participantKind", exception.Message, StringComparison.Ordinal);
+    }
+
     private static NegotiationIdentityResolver CreateIdentityResolver(FunctionsHostOptions options) =>
         new(Options.Create(options));
+
+    private static (bool Success, NegotiationIdentity Identity, HttpStatusCode StatusCode, string FailureMessage)
+        ResolveInTrustedFunctionBoundary(
+            NegotiationIdentityResolver resolver,
+            Uri requestUri,
+            HttpHeadersCollection headers) =>
+        WithEnvironmentVariable(
+            WebsiteInstanceIdEnvironmentVariable,
+            "trusted-boundary",
+            () =>
+            {
+                var success = resolver.TryResolve(
+                    requestUri,
+                    headers,
+                    out var identity,
+                    out var statusCode,
+                    out var failureMessage);
+
+                return (success, identity, statusCode, failureMessage);
+            });
+
+    private static T WithEnvironmentVariable<T>(string name, string? value, Func<T> action)
+    {
+        lock (EnvironmentVariableSync)
+        {
+            var original = Environment.GetEnvironmentVariable(name);
+            try
+            {
+                Environment.SetEnvironmentVariable(name, value);
+                return action();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(name, original);
+            }
+        }
+    }
+
+    private static string CreatePrincipalPayload(string principalId, string identityProvider)
+    {
+        var payload = new
+        {
+            auth_typ = identityProvider,
+            userId = principalId,
+            claims = new[]
+            {
+                new
+                {
+                    typ = "http://schemas.microsoft.com/identity/claims/objectidentifier",
+                    val = principalId
+                }
+            }
+        };
+
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(payload)));
+    }
 
     private sealed class RecordingAccessUriClient : IWebPubSubAccessUriClient
     {


### PR DESCRIPTION
## Summary
- trust Easy Auth headers only inside the Azure Functions host boundary and reject mismatched principal payloads
- bind PubSub user identities to project/session scope, reject broker-scoped client negotiate requests, and trim the public negotiate response
- add targeted negotiate claim and authorization tests plus Morpheus history updates

## Validation
- dotnet test .\\tests\\SquadScout.Broker.Tests\\SquadScout.Broker.Tests.csproj -nologo --filter PubSubNegotiateEndpointTests --no-build
- dotnet build .\\SquadScout.slnx -nologo
- dotnet test .\\SquadScout.slnx -nologo --no-build

closes #12