### PR TITLE
Add Aspire orchestration and ServiceDefaults

### DIFF
--- a/SquadScout.slnx
+++ b/SquadScout.slnx
@@ -1,9 +1,11 @@
 <Solution>
   <Folder Name="/src/">
     <Project Path="src/SquadScout.App/SquadScout.App.csproj" />
+    <Project Path="src/SquadScout.AppHost/SquadScout.AppHost.csproj" />
     <Project Path="src/SquadScout.Broker/SquadScout.Broker.csproj" />
     <Project Path="src/SquadScout.Contracts/SquadScout.Contracts.csproj" />
     <Project Path="src/SquadScout.Functions/SquadScout.Functions.csproj" />
+    <Project Path="src/SquadScout.ServiceDefaults/SquadScout.ServiceDefaults.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/SquadScout.App.Tests/SquadScout.App.Tests.csproj" />

--- a/src/SquadScout.App/MauiProgram.cs
+++ b/src/SquadScout.App/MauiProgram.cs
@@ -1,8 +1,9 @@
-﻿using SquadScout.App.Configuration;
+using SquadScout.App.Configuration;
 using SquadScout.App.Infrastructure;
 using SquadScout.App.Navigation;
 using SquadScout.App.Services;
 using SquadScout.App.ViewModels;
+using Microsoft.Extensions.Hosting;
 
 namespace SquadScout.App;
 
@@ -11,6 +12,7 @@ public static class MauiProgram
 	public static MauiApp CreateMauiApp()
 	{
 		var builder = MauiApp.CreateBuilder();
+		builder.AddServiceDefaults();
 		builder
 			.UseMauiApp<App>()
 			.ConfigureFonts(fonts =>
@@ -31,11 +33,13 @@ public static class MauiProgram
 		builder.Services.AddSingleton(authOptions);
 		builder.Services.AddSingleton(messagingOptions);
 		builder.Services.AddSingleton(localDevelopmentOptions);
-		builder.Services.AddSingleton(new HttpClient
+		builder.Services.AddHttpClient("BrokerApi", client =>
 		{
-			BaseAddress = AppConfiguration.CreateBrokerBaseUri(brokerApiOptions),
-			Timeout = TimeSpan.FromSeconds(Math.Max(1, brokerApiOptions.RequestTimeoutSeconds))
+			client.BaseAddress = AppConfiguration.CreateBrokerBaseUri(brokerApiOptions);
+			client.Timeout = TimeSpan.FromSeconds(Math.Max(1, brokerApiOptions.RequestTimeoutSeconds));
 		});
+		builder.Services.AddSingleton(serviceProvider =>
+			serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient("BrokerApi"));
 		builder.Services.AddSingleton<IAppNavigator, ShellNavigator>();
 		builder.Services.AddSingleton<IAuthenticationService, ConfiguredAuthenticationService>();
 		builder.Services.AddSingleton<IMessageConnectionService, MessagingConnectionService>();

--- a/src/SquadScout.App/SquadScout.App.csproj
+++ b/src/SquadScout.App/SquadScout.App.csproj
@@ -69,6 +69,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\SquadScout.Contracts\SquadScout.Contracts.csproj" />
+		<ProjectReference Include="..\SquadScout.ServiceDefaults\SquadScout.ServiceDefaults.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SquadScout.AppHost/AppHost.cs
+++ b/src/SquadScout.AppHost/AppHost.cs
@@ -1,0 +1,14 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+var broker = builder.AddProject<Projects.SquadScoutBroker>("broker", launchProfileName: null)
+    .WithHttpEndpoint(name: "http", port: 5071, isProxied: false)
+    .WithHttpHealthCheck("/health");
+
+builder.AddAzureFunctionsProject<Projects.SquadScoutFunctions>("functions");
+
+builder.AddMauiProject("app", @"..\SquadScout.App\SquadScout.App.csproj")
+    .AddWindowsDevice()
+    .WithReference(broker)
+    .WithEnvironment("SQUADSCOUT_BROKERAPI__BASEURL", broker.GetEndpoint("http"));
+
+builder.Build().Run();

--- a/src/SquadScout.AppHost/Properties/launchSettings.json
+++ b/src/SquadScout.AppHost/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17090;http://localhost:15284",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21175",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://localhost:23168",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22132"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15284",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19163",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://localhost:18256",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20052"
+      }
+    }
+  }
+}

--- a/src/SquadScout.AppHost/SquadScout.AppHost.csproj
+++ b/src/SquadScout.AppHost/SquadScout.AppHost.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Aspire.AppHost.Sdk/13.2.0">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>a0068770-a7ab-4c24-aae8-7d4fa1c8d52e</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.Azure.Functions" Version="13.2.0" />
+    <PackageReference Include="Aspire.Hosting.Maui" Version="13.2.0-preview.1.26170.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SquadScout.Broker\SquadScout.Broker.csproj" AspireProjectMetadataTypeName="SquadScoutBroker" />
+    <ProjectReference Include="..\SquadScout.Functions\SquadScout.Functions.csproj" AspireProjectMetadataTypeName="SquadScoutFunctions" />
+  </ItemGroup>
+
+</Project>

--- a/src/SquadScout.AppHost/appsettings.Development.json
+++ b/src/SquadScout.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/SquadScout.AppHost/appsettings.json
+++ b/src/SquadScout.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/src/SquadScout.AppHost/aspire.config.json
+++ b/src/SquadScout.AppHost/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "SquadScout.AppHost.csproj"
+  }
+}

--- a/src/SquadScout.Broker/Program.cs
+++ b/src/SquadScout.Broker/Program.cs
@@ -4,11 +4,34 @@ using SquadScout.Broker.Projects;
 using SquadScout.Broker.Relay;
 using SquadScout.Broker.Sessions;
 using SquadScout.Contracts.Messages;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.AddServiceDefaults();
+builder.Services
+    .AddHealthChecks()
+    .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics => metrics.AddAspNetCoreInstrumentation())
+    .WithTracing(tracing =>
+    {
+        tracing.AddAspNetCoreInstrumentation(options =>
+        {
+            options.Filter = context =>
+                !context.Request.Path.StartsWithSegments("/health")
+                && !context.Request.Path.StartsWithSegments("/alive");
+        });
+    });
 
 var brokerOptions = builder.Configuration.GetSection(BrokerHostOptions.SectionName).Get<BrokerHostOptions>() ?? new BrokerHostOptions();
-builder.WebHost.UseUrls(brokerOptions.ListenUrl);
+if (string.IsNullOrWhiteSpace(builder.Configuration[WebHostDefaults.ServerUrlsKey]))
+{
+    builder.WebHost.UseUrls(brokerOptions.ListenUrl);
+}
 
 builder.Services.Configure<BrokerHostOptions>(builder.Configuration.GetSection(BrokerHostOptions.SectionName));
 builder.Services.Configure<CopilotPtyHostOptions>(builder.Configuration.GetSection(CopilotPtyHostOptions.SectionName));
@@ -21,6 +44,13 @@ builder.Services.AddSingleton<ISequenceValidator, SessionSequenceValidator>();
 builder.Services.AddSingleton<ISessionOrchestrator, InMemorySessionOrchestrator>();
 
 var app = builder.Build();
+if (app.Environment.IsDevelopment())
+{
+    app.MapHealthChecks("/alive", new HealthCheckOptions
+    {
+        Predicate = registration => registration.Tags.Contains("live")
+    });
+}
 
 app.MapGet("/", () => Results.Ok(new
 {

--- a/src/SquadScout.Broker/SquadScout.Broker.csproj
+++ b/src/SquadScout.Broker/SquadScout.Broker.csproj
@@ -8,9 +8,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SquadScout.Contracts\SquadScout.Contracts.csproj" />
+    <ProjectReference Include="..\SquadScout.ServiceDefaults\SquadScout.ServiceDefaults.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
     <PackageReference Include="sch.pty.net" Version="0.3.36-pre" GeneratePathProperty="true" />
   </ItemGroup>
 
@@ -19,10 +21,7 @@
       <PtyNetNativeFiles Include="$(Pkgsch_pty_net)\build\$(PlatformTarget)\**\*" />
     </ItemGroup>
 
-    <Copy
-      SourceFiles="@(PtyNetNativeFiles)"
-      DestinationFiles="@(PtyNetNativeFiles->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')"
-      SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(PtyNetNativeFiles)" DestinationFiles="@(PtyNetNativeFiles->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
   </Target>
 
 </Project>

--- a/src/SquadScout.Functions/Program.cs
+++ b/src/SquadScout.Functions/Program.cs
@@ -2,6 +2,8 @@ using Azure.Core;
 using Azure.Core.Serialization;
 using Azure.Identity;
 using Azure.Messaging.WebPubSub;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System.Text.Json;
@@ -15,43 +17,42 @@ var jsonOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
 };
 jsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
 
-var host = new HostBuilder()
-    .ConfigureFunctionsWorkerDefaults(worker =>
+var builder = FunctionsApplication.CreateBuilder(args);
+builder.AddServiceDefaults();
+
+builder.Services.Configure<WorkerOptions>(options =>
+{
+    options.Serializer = new JsonObjectSerializer(jsonOptions);
+});
+
+builder.Services
+    .AddOptions<FunctionsHostOptions>()
+    .Bind(builder.Configuration.GetSection(FunctionsHostOptions.SectionName))
+    .ValidateDataAnnotations()
+    .Validate(
+        options => Uri.TryCreate(options.WebPubSubEndpoint, UriKind.Absolute, out _),
+        $"{FunctionsHostOptions.SectionName}:WebPubSubEndpoint must be an absolute URI.")
+    .ValidateOnStart();
+
+builder.Services.AddSingleton<TimeProvider>(_ => TimeProvider.System);
+builder.Services.AddSingleton<TokenCredential>(serviceProvider =>
+{
+    var options = serviceProvider.GetRequiredService<Microsoft.Extensions.Options.IOptions<FunctionsHostOptions>>().Value;
+    return new DefaultAzureCredential(new DefaultAzureCredentialOptions
     {
-        worker.Serializer = new JsonObjectSerializer(jsonOptions);
-    })
-    .ConfigureServices((context, services) =>
-    {
-        services
-            .AddOptions<FunctionsHostOptions>()
-            .Bind(context.Configuration.GetSection(FunctionsHostOptions.SectionName))
-            .ValidateDataAnnotations()
-            .Validate(
-                options => Uri.TryCreate(options.WebPubSubEndpoint, UriKind.Absolute, out _),
-                $"{FunctionsHostOptions.SectionName}:WebPubSubEndpoint must be an absolute URI.")
-            .ValidateOnStart();
+        ManagedIdentityClientId = options.ManagedIdentityClientId,
+        ExcludeInteractiveBrowserCredential = true
+    });
+});
 
-        services.AddSingleton<TimeProvider>(_ => TimeProvider.System);
-        services.AddSingleton<TokenCredential>(serviceProvider =>
-        {
-            var options = serviceProvider.GetRequiredService<Microsoft.Extensions.Options.IOptions<FunctionsHostOptions>>().Value;
-            return new DefaultAzureCredential(new DefaultAzureCredentialOptions
-            {
-                ManagedIdentityClientId = options.ManagedIdentityClientId,
-                ExcludeInteractiveBrowserCredential = true
-            });
-        });
+builder.Services.AddSingleton(serviceProvider =>
+{
+    var options = serviceProvider.GetRequiredService<Microsoft.Extensions.Options.IOptions<FunctionsHostOptions>>().Value;
+    var credential = serviceProvider.GetRequiredService<TokenCredential>();
+    return new WebPubSubServiceClient(new Uri(options.WebPubSubEndpoint), options.WebPubSubHub, credential);
+});
+builder.Services.AddSingleton<IWebPubSubAccessUriClient, ManagedIdentityWebPubSubAccessUriClient>();
+builder.Services.AddSingleton<NegotiationIdentityResolver>();
+builder.Services.AddSingleton<WebPubSubNegotiationService>();
 
-        services.AddSingleton(serviceProvider =>
-        {
-            var options = serviceProvider.GetRequiredService<Microsoft.Extensions.Options.IOptions<FunctionsHostOptions>>().Value;
-            var credential = serviceProvider.GetRequiredService<TokenCredential>();
-            return new WebPubSubServiceClient(new Uri(options.WebPubSubEndpoint), options.WebPubSubHub, credential);
-        });
-        services.AddSingleton<IWebPubSubAccessUriClient, ManagedIdentityWebPubSubAccessUriClient>();
-        services.AddSingleton<NegotiationIdentityResolver>();
-        services.AddSingleton<WebPubSubNegotiationService>();
-    })
-    .Build();
-
-host.Run();
+builder.Build().Run();

--- a/src/SquadScout.Functions/SquadScout.Functions.csproj
+++ b/src/SquadScout.Functions/SquadScout.Functions.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SquadScout.Contracts\SquadScout.Contracts.csproj" />
+    <ProjectReference Include="..\SquadScout.ServiceDefaults\SquadScout.ServiceDefaults.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SquadScout.ServiceDefaults/Extensions.cs
+++ b/src/SquadScout.ServiceDefaults/Extensions.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+#if NET10_0_OR_GREATER
+using Microsoft.Maui.Hosting;
+#endif
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Extensions.Hosting;
+
+public static class Extensions
+{
+    public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.ConfigureCommonOpenTelemetry();
+
+        builder.Services.AddServiceDiscovery();
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            http.AddStandardResilienceHandler();
+            http.AddServiceDiscovery();
+        });
+
+#if NET10_0_OR_GREATER
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IMauiInitializeService, OpenTelemetryInitializer>(_ => new OpenTelemetryInitializer()));
+#endif
+
+        return builder;
+    }
+
+    private static TBuilder ConfigureCommonOpenTelemetry<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Logging.AddOpenTelemetry(options =>
+        {
+            options.IncludeFormattedMessage = true;
+            options.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                tracing.AddSource(builder.Environment.ApplicationName)
+                    .AddHttpClientInstrumentation();
+            });
+
+        builder.AddOpenTelemetryExporters();
+        return builder;
+    }
+
+    private static TBuilder AddOpenTelemetryExporters<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"])
+            || !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT_URL"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+
+        return builder;
+    }
+
+#if NET10_0_OR_GREATER
+    private sealed class OpenTelemetryInitializer : IMauiInitializeService
+    {
+        public void Initialize(IServiceProvider services)
+        {
+            _ = services.GetService<MeterProvider>();
+            _ = services.GetService<TracerProvider>();
+            _ = services.GetService<ILoggerProvider>();
+        }
+    }
+#endif
+}

--- a/src/SquadScout.ServiceDefaults/SquadScout.ServiceDefaults.csproj
+++ b/src/SquadScout.ServiceDefaults/SquadScout.ServiceDefaults.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.2.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.2.0" />
+    <PackageReference Include="Microsoft.Maui.Core" Version="10.0.20" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add a new SquadScout.AppHost Aspire orchestration project plus a shared SquadScout.ServiceDefaults project
- wire SquadScout.Broker, SquadScout.Functions, and SquadScout.App into the shared logging/OpenTelemetry and HttpClient defaults
- preserve current broker behavior while letting Aspire orchestrate the broker, Functions worker, and Windows MAUI client flow

## Validation
- dotnet build .\\SquadScout.slnx -nologo
- dotnet test .\\SquadScout.slnx -nologo --no-build
- dotnet run --project .\\src\\SquadScout.AppHost\\SquadScout.AppHost.csproj --no-build (smoke start)

refs #31