### PR TITLE
Polish Aspire broker and MAUI wiring

### DIFF
--- a/.squad/agents/seraph/history.md
+++ b/.squad/agents/seraph/history.md
@@ -36,3 +36,10 @@
 - **Single-user + multi-machine design confirmed.** Design local broker scaffolding to support multiple developers with separate Azure credentials; no shared multi-user backend until post-MVP.
 - **App-level sequencing/replay via Orleans confirmed** as source of truth, not Web PubSub features. Service-tier reliability features not required; Orleans grain single-threaded execution enforces atomicity.
 - **Status:** All 6 Seraph workstreams aligned to Neo's unified decomposition. WS-3 (PubSub routing) and WS-4 (token refresh/reconnect) priority path locked. Ready for Phase 1 execution.
+
+### 2026-03-25: Aspire orchestration + ServiceDefaults groundwork
+
+- Aligned the repo's new Aspire AppHost and ServiceDefaults rollout with Seraph-owned startup concerns after the shared Aspire scaffolding landed on main.
+- Documented why the shared defaults project stays multi-targeted for net8.0 and net10.0 so the Azure Functions worker can opt into AddServiceDefaults() while the MAUI app can initialize OpenTelemetry via the MAUI-specific startup hook.
+- Preserved broker compatibility by surfacing the effective ASP.NET Core listen URL in the root status payload while still letting standalone runs honor Broker:ListenUrl.
+- Updated the MAUI app to create broker clients through an Aspire-configured HttpClient factory seam so resilience and future service discovery can flow into mobile-to-broker calls without breaking offline fallbacks.

--- a/.squad/decisions/inbox/seraph-aspire-service-defaults.md
+++ b/.squad/decisions/inbox/seraph-aspire-service-defaults.md
@@ -1,0 +1,17 @@
+# Seraph: Aspire ServiceDefaults decision
+
+## Context
+- SquadScout.Functions remains on net8.0 while SquadScout.App and SquadScout.Broker target net10.0.
+- We wanted one reviewable Aspire introduction that helps telemetry/logging work without disrupting current broker and MAUI behavior.
+
+## Decision
+- Use a custom shared src\SquadScout.ServiceDefaults project that multi-targets net8.0;net10.0 instead of the stock ASP.NET Core-only ServiceDefaults shape.
+- Keep broker health behavior on its existing explicit /health endpoint instead of switching to Aspire health endpoint mapping.
+- Let Aspire AppHost own broker endpoint orchestration when it sets ASPNETCORE_URLS; otherwise the broker keeps using Broker:ListenUrl.
+
+## Why
+- The stock Aspire ServiceDefaults template assumes ASP.NET Core health-check wiring, but the MAUI app needs the MAUI OpenTelemetry initializer pattern and the Functions worker needs a net8.0-compatible shared project.
+- This keeps one shared defaults project for logging, OTEL, resilience, and service discovery while minimizing behavioral changes in existing endpoints and configs.
+
+## Follow-up
+- If issue #31 grows into end-to-end trace correlation work, layer broker-specific incoming-request instrumentation and Azure Monitor export settings on top of this shared foundation.

--- a/src/SquadScout.App/MauiProgram.cs
+++ b/src/SquadScout.App/MauiProgram.cs
@@ -38,8 +38,8 @@ public static class MauiProgram
 			client.BaseAddress = AppConfiguration.CreateBrokerBaseUri(brokerApiOptions);
 			client.Timeout = TimeSpan.FromSeconds(Math.Max(1, brokerApiOptions.RequestTimeoutSeconds));
 		});
-		builder.Services.AddSingleton(serviceProvider =>
-			serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient("BrokerApi"));
+		builder.Services.AddSingleton<Func<HttpClient>>(
+			static services => () => services.GetRequiredService<IHttpClientFactory>().CreateClient("BrokerApi"));
 		builder.Services.AddSingleton<IAppNavigator, ShellNavigator>();
 		builder.Services.AddSingleton<IAuthenticationService, ConfiguredAuthenticationService>();
 		builder.Services.AddSingleton<IMessageConnectionService, MessagingConnectionService>();

--- a/src/SquadScout.App/Services/BrokerBackedMobileServices.cs
+++ b/src/SquadScout.App/Services/BrokerBackedMobileServices.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http.Json;
 using SquadScout.App.Configuration;
 using SquadScout.Contracts.Projects;
@@ -74,25 +74,27 @@ public sealed class MessagingConnectionService : IMessageConnectionService
 
 public sealed class BrokerProjectCatalogService : IProjectCatalogService
 {
-    private readonly HttpClient _httpClient;
+    private readonly Func<HttpClient> _createHttpClient;
     private readonly AppEnvironment _environment;
     private readonly LocalDevelopmentOptions _localDevelopmentOptions;
 
     public BrokerProjectCatalogService(
-        HttpClient httpClient,
+        Func<HttpClient> createHttpClient,
         AppEnvironment environment,
         LocalDevelopmentOptions localDevelopmentOptions)
     {
-        _httpClient = httpClient;
+        _createHttpClient = createHttpClient;
         _environment = environment;
         _localDevelopmentOptions = localDevelopmentOptions;
     }
 
     public async Task<ProjectCatalogSnapshot> GetProjectsAsync(CancellationToken cancellationToken = default)
     {
+        using var httpClient = _createHttpClient();
+
         try
         {
-            var projects = await _httpClient.GetFromJsonAsync<RegisteredProject[]>("api/projects", cancellationToken)
+            var projects = await httpClient.GetFromJsonAsync<RegisteredProject[]>("api/projects", cancellationToken)
                 ?? Array.Empty<RegisteredProject>();
 
             if (projects.Length > 0 || !CanUseFallbackProjects())
@@ -133,25 +135,27 @@ public sealed class BrokerSessionLifecycleService : ISessionLifecycleService
 {
     internal const string LocalDevelopmentSessionPrefix = "localdev-";
 
-    private readonly HttpClient _httpClient;
+    private readonly Func<HttpClient> _createHttpClient;
     private readonly AppEnvironment _environment;
     private readonly LocalDevelopmentOptions _localDevelopmentOptions;
 
     public BrokerSessionLifecycleService(
-        HttpClient httpClient,
+        Func<HttpClient> createHttpClient,
         AppEnvironment environment,
         LocalDevelopmentOptions localDevelopmentOptions)
     {
-        _httpClient = httpClient;
+        _createHttpClient = createHttpClient;
         _environment = environment;
         _localDevelopmentOptions = localDevelopmentOptions;
     }
 
     public async Task<SessionLaunchResult> StartAsync(StartSessionCommand command, CancellationToken cancellationToken = default)
     {
+        using var httpClient = _createHttpClient();
+
         try
         {
-            using var response = await _httpClient.PostAsJsonAsync("api/sessions", command, cancellationToken);
+            using var response = await httpClient.PostAsJsonAsync("api/sessions", command, cancellationToken);
             response.EnsureSuccessStatusCode();
 
             var session = await response.Content.ReadFromJsonAsync<SessionDescriptor>(cancellationToken: cancellationToken)
@@ -184,7 +188,8 @@ public sealed class BrokerSessionLifecycleService : ISessionLifecycleService
             return null;
         }
 
-        using var response = await _httpClient.GetAsync($"api/sessions/{Uri.EscapeDataString(sessionId)}", cancellationToken);
+        using var httpClient = _createHttpClient();
+        using var response = await httpClient.GetAsync($"api/sessions/{Uri.EscapeDataString(sessionId)}", cancellationToken);
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
             return null;

--- a/src/SquadScout.Broker/Program.cs
+++ b/src/SquadScout.Broker/Program.cs
@@ -28,6 +28,7 @@ builder.Services.AddOpenTelemetry()
     });
 
 var brokerOptions = builder.Configuration.GetSection(BrokerHostOptions.SectionName).Get<BrokerHostOptions>() ?? new BrokerHostOptions();
+var effectiveListenUrl = builder.Configuration[WebHostDefaults.ServerUrlsKey] ?? brokerOptions.ListenUrl;
 if (string.IsNullOrWhiteSpace(builder.Configuration[WebHostDefaults.ServerUrlsKey]))
 {
     builder.WebHost.UseUrls(brokerOptions.ListenUrl);
@@ -55,7 +56,7 @@ if (app.Environment.IsDevelopment())
 app.MapGet("/", () => Results.Ok(new
 {
     service = "SquadScout Broker",
-    listenUrl = brokerOptions.ListenUrl,
+    listenUrl = effectiveListenUrl,
     localUi = "reserved for the co-hosted Blazor Server admin shell",
     relay = "reserved for Azure Web PubSub integration",
     state = "reserved for Orleans-backed session ownership"

--- a/tests/SquadScout.App.Tests/MobileShellScaffoldTests.cs
+++ b/tests/SquadScout.App.Tests/MobileShellScaffoldTests.cs
@@ -57,7 +57,7 @@ public sealed class MobileShellScaffoldTests
         };
 
         var service = new BrokerProjectCatalogService(
-            httpClient,
+            () => httpClient,
             new AppEnvironment(AppEnvironment.DevelopmentName),
             new LocalDevelopmentOptions
             {
@@ -89,7 +89,7 @@ public sealed class MobileShellScaffoldTests
         };
 
         var service = new BrokerSessionLifecycleService(
-            httpClient,
+            () => httpClient,
             new AppEnvironment(AppEnvironment.DevelopmentName),
             new LocalDevelopmentOptions
             {


### PR DESCRIPTION
## Summary
- switch MAUI broker services to create Aspire-configured HttpClient instances through a factory seam instead of caching a singleton client
- surface the broker's effective ASP.NET Core listen URL so AppHost-driven endpoint overrides show up correctly in the broker status payload
- capture the Seraph history/decision follow-up for the repo's shared Aspire ServiceDefaults shape

## Validation
- dotnet build .\\SquadScout.slnx -nologo
- dotnet test .\\SquadScout.slnx -nologo --no-build

Related to #31.