### PR TITLE
Clarify CopilotPtyHostOptions.WorkingDirectory semantics and logging

### DIFF
--- a/src/SquadScout.Broker/Configuration/CopilotPtyHostOptions.cs
+++ b/src/SquadScout.Broker/Configuration/CopilotPtyHostOptions.cs
@@ -10,6 +10,18 @@ public sealed class CopilotPtyHostOptions
 
     public string[] BaseArguments { get; set; } = Array.Empty<string>();
 
+    /// <summary>
+    /// Gets or sets the fallback working directory for Copilot PTY sessions when a project does not have a configured RepositoryRoot.
+    /// This value is only used if the project's RepositoryRoot is null or empty.
+    /// If this value is also empty, the broker's current working directory is used.
+    /// In normal operation, each session uses its project's RepositoryRoot as the working directory.
+    /// </summary>
+    /// <remarks>
+    /// Working directory resolution priority:
+    /// 1. Project RepositoryRoot (set via project registration)
+    /// 2. This fallback value (CopilotPtyHostOptions.WorkingDirectory)
+    /// 3. Current broker process directory (Environment.CurrentDirectory)
+    /// </remarks>
     public string WorkingDirectory { get; set; } = string.Empty;
 
     public int InitialRows { get; set; } = 30;

--- a/src/SquadScout.Broker/Pty/CopilotPtyHost.cs
+++ b/src/SquadScout.Broker/Pty/CopilotPtyHost.cs
@@ -97,18 +97,37 @@ public sealed class CopilotPtyHost : IPtyHost
 
     private string ResolveWorkingDirectory(PtySessionStartRequest request)
     {
-        var workingDirectory = !string.IsNullOrWhiteSpace(request.WorkingDirectory)
-            ? request.WorkingDirectory
-            : !string.IsNullOrWhiteSpace(_options.WorkingDirectory)
-                ? _options.WorkingDirectory
-                : Environment.CurrentDirectory;
+        string workingDirectory;
+        string source;
+
+        if (!string.IsNullOrWhiteSpace(request.WorkingDirectory))
+        {
+            workingDirectory = request.WorkingDirectory;
+            source = "project repository root";
+        }
+        else if (!string.IsNullOrWhiteSpace(_options.WorkingDirectory))
+        {
+            workingDirectory = _options.WorkingDirectory;
+            source = "broker default configuration";
+        }
+        else
+        {
+            workingDirectory = Environment.CurrentDirectory;
+            source = "current broker process directory";
+        }
 
         if (!Directory.Exists(workingDirectory))
         {
             throw new DirectoryNotFoundException($"The PTY working directory '{workingDirectory}' does not exist.");
         }
 
-        return Path.GetFullPath(workingDirectory);
+        var resolvedPath = Path.GetFullPath(workingDirectory);
+        _logger.LogInformation(
+            "Using working directory from {Source}: {WorkingDirectory}",
+            source,
+            resolvedPath);
+
+        return resolvedPath;
     }
 
     private Dictionary<string, string> CreateEnvironment(PtySessionStartRequest request)

--- a/src/SquadScout.Broker/appsettings.json
+++ b/src/SquadScout.Broker/appsettings.json
@@ -9,6 +9,9 @@
     "InitialColumns": 120,
     "OutputBufferSize": 1024,
     "MaxInputCharactersPerWrite": 4096
+    // WorkingDirectory: Optional fallback when project has no RepositoryRoot.
+    // In normal operation, each session uses its project's RepositoryRoot as the working directory.
+    // Resolution priority: 1) Project RepositoryRoot, 2) This fallback, 3) Broker process directory.
   },
   "AzureWebPubSub": {
     "Hub": "squadscout",


### PR DESCRIPTION
## Summary
- clarify that CopilotPtyHostOptions.WorkingDirectory is optional and only applied when configured
- improve host logging around configured and fallback working directories
- expose the broker setting in appsettings.json

## Testing
- dotnet build .\SquadScout.slnx -nologo
- dotnet test .\SquadScout.slnx -nologo --no-build

closes #59