### PR TITLE
Add Bicep infrastructure as code for Azure components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ TestResults/
 
 # Azure Functions local configuration
 local.settings.json
+
+# Bicep compiled ARM templates
+infra/**/*.json
+!infra/main.parameters.json
+!infra/abbreviations.json

--- a/infra/README.md
+++ b/infra/README.md
@@ -69,7 +69,6 @@ Required parameters in `main.bicep`:
 |-----------|-------------|---------|---------|
 | `environmentName` | Environment name (used for resource naming) | (required) | `dev`, `staging`, `prod` |
 | `location` | Azure region for all resources | (required) | `eastus`, `westus2` |
-| `principalId` | Optional: Azure AD principal for additional RBAC | `""` | GUID of user/service principal |
 
 ### Deployment Outputs
 

--- a/infra/core/host/functions.bicep
+++ b/infra/core/host/functions.bicep
@@ -74,7 +74,7 @@ resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
     serverFarmId: appServicePlan.id
     httpsOnly: true
     siteConfig: {
-      linuxFxVersion: '${upper(runtime)}|${runtimeVersion}'
+      linuxFxVersion: '${toUpper(runtime)}|${runtimeVersion}'
       ftpsState: 'Disabled'
       minTlsVersion: '1.2'
       use32BitWorkerProcess: false

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -9,9 +9,6 @@ param environmentName string
 @description('Primary location for all resources')
 param location string
 
-@description('Id of the user or app to assign application roles')
-param principalId string = ''
-
 // Tags applied to all resources
 var tags = {
   'azd-env-name': environmentName

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -7,9 +7,6 @@
     },
     "location": {
       "value": "${AZURE_LOCATION=eastus}"
-    },
-    "principalId": {
-      "value": "${AZURE_PRINCIPAL_ID=}"
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR implements Phase 1 infrastructure as code using Bicep templates with AZD compatibility.

## Changes

- **Azure resources**: Web PubSub (Free tier), Azure Functions (Consumption), Application Insights, Log Analytics, Storage
- **Security**: Functions use system-assigned managed identity with Web PubSub Service Owner RBAC (no connection strings)
- **Structure**: Modular Bicep templates in `infra/core/` following AZD conventions
- **AZD support**: `azure.yaml` enables `azd provision`/`azd deploy` workflows
- **Documentation**: Comprehensive `infra/README.md` with deployment guidance and cost considerations
- **Validation fixes**: Corrected Bicep syntax (toUpper instead of upper), removed unused parameters, added gitignore for compiled artifacts

## Validation

- ✅ `az bicep build` passes without errors or warnings
- ✅ `dotnet build .\SquadScout.slnx -nologo` succeeded
- ✅ `dotnet test .\SquadScout.slnx -nologo --no-build` passed (131/131 tests)
- ✅ Infrastructure matches current Phase 1 cloud footprint (Functions + Web PubSub)
- ✅ No speculative Phase 2 resources added

## Deployment

Deployment outputs provide all configuration values needed for:
- `local.settings.json` (Functions development)
- MAUI app negotiate endpoint configuration

See `infra/README.md` for detailed deployment instructions and manual Web PubSub event handler configuration step.

Closes #62

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
