### PR TITLE
Closes #20: add Orleans project grain migration path

### DIFF
--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -1246,3 +1246,31 @@ Issue #19 promotes broker session state from the Phase 1 in-memory registry into
 - `dotnet test .\SquadScout.slnx -nologo --no-build` ✅
 - `dotnet run --project .\src\SquadScout.Broker\SquadScout.Broker.csproj --no-build --no-launch-profile` with `Orleans__Enabled=true` and SQLite smoke settings ✅
 - `GET http://127.0.0.1:5075/api/orleans/status` returned `hostMode=session-grains`, `sessionStateMode=durable-grain`, and `schemaReady=true` ✅
+
+## Link — Issue #20 Project Grain & State Migration Path (2026-03-26)
+
+### Decision
+
+Issue #20 promotes the broker project catalog from the Phase 1 in-memory registry into a **durable Orleans project grain path**:
+- keep one durable project grain per `projectId` for registration lookup
+- add a persisted project registry grain for list/query operations and Phase 1 seed-import tracking
+- keep session grains attached by `projectId` only; PTY ownership and live transport lifecycle stay outside grains in the broker relay/runtime path
+
+### Rationale
+
+- Project registration is the remaining Phase 1 metadata seam after #19. Persisting it closes the loop so both project and session metadata survive broker restarts without inventing a second persistence model.
+- Sessions already persist their `ProjectId` in `ISessionGrain`; reusing that attachment avoids duplicating transport/runtime ownership inside project grains while still binding sessions to durable project state.
+- A safe cutover needs an explicit bridge: if the current broker process already seeded the old in-memory catalog, the Orleans-backed catalog imports those registrations on first durable access so local admin/testing flows do not lose project metadata mid-process.
+
+### Implementation Notes
+
+- `src\SquadScout.Broker\Orleans\ProjectGrainModels.cs` defines durable registration DTOs plus the persisted project registry snapshot used for list/query and Phase 1 seed-import metadata.
+- `src\SquadScout.Broker\Orleans\ProjectGrain.cs` and `ProjectRegistryGrain.cs` mirror the session-grain load/persist pattern so direct project lookup and catalog listing share the same Orleans storage model.
+- `src\SquadScout.Broker\Projects\GrainBackedProjectCatalog.cs` preserves the existing `IProjectCatalog` seam, imports any already-seeded Phase 1 projects once, and mirrors subsequent writes into durable grains without changing relay/PTTY ownership.
+- `src\SquadScout.Broker\Program.cs` now switches Orleans-enabled brokers onto the grain-backed project catalog and advertises `hostMode=session-project-grains` plus `projectStateMode=durable-grain` through `/api/orleans/status`.
+- Compatibility note: durable metadata does **not** revive active PTY sessions. Operators should drain or restart running sessions before toggling Orleans mode across a cutover.
+
+### Validation
+
+- `dotnet build .\SquadScout.slnx -nologo` ✅
+- `dotnet test .\SquadScout.slnx -nologo --no-build` ✅

--- a/docs/BROKER_SETUP.md
+++ b/docs/BROKER_SETUP.md
@@ -27,7 +27,7 @@ dotnet run --launch-profile Development
 
 **Defaults (appsettings.json):**
 - **Listen URL:** `http://127.0.0.1:5071`
-- **Project Registry:** `.squadscout/projects.json` (in-memory, not persisted)
+- **Project Registry Setting:** `.squadscout/projects.json` (reserved configuration key; the broker uses the Phase 1 in-memory catalog when Orleans is disabled and durable project grains when Orleans is enabled)
 - **Copilot Executable:** `copilot` (from PATH)
 - **PTY Buffer:** 1024 characters; 30 rows × 120 columns
 - **Azure Web PubSub:** Disabled (empty ConnectionString)
@@ -68,7 +68,7 @@ All broker settings are **environment-driven** via `appsettings.json` and overri
 | Setting | Type | Default | Notes |
 |---------|------|---------|-------|
 | `ListenUrl` | string | `http://127.0.0.1:5071` | HTTP server bind address. Use `http://localhost:5071` for remote calls; `http://127.0.0.1:5071` restricts to loopback. |
-| `ProjectRegistryPath` | string | `.squadscout\projects.json` | Relative path for persisting registered projects. Not yet implemented; in-memory catalog used. |
+| `ProjectRegistryPath` | string | `.squadscout\projects.json` | Reserved migration setting for the Phase 1 project registry path. Current runtime behavior is mode-driven: in-memory catalog when Orleans is disabled, durable project grains when Orleans is enabled. |
 
 **Override at runtime:**
 
@@ -164,17 +164,26 @@ dotnet run \
 - No publish to remote clients (NullRelayPublisher used).
 - Suitable for local testing and debugging.
 
-### Orleans (Phase 2 — Currently Disabled)
+### Orleans (Phase 2 — Durable Metadata)
 
 ```json
 {
   "Orleans": {
-    "Enabled": false
+    "Enabled": true
   }
 }
 ```
 
-Orleans-based session grain distribution is not yet implemented. Leave `Enabled: false` for Phase 1.
+When `Orleans:Enabled=true`, the broker starts a local silo and stores:
+
+- **Session metadata + replay state** in durable session grains
+- **Project registrations** in durable project grains plus a persisted registry grain
+
+Compatibility constraints during cutover:
+
+- **PTY ownership stays outside grains.** Durable metadata does not revive live Copilot PTY processes.
+- **Drain or restart running sessions before toggling Orleans mode.** Session descriptors and project registrations persist, but active transports still require a fresh broker-owned start.
+- **Phase 1 bridge:** if the current broker process already seeded the in-memory project catalog, the Orleans-backed catalog imports those registrations on first durable access so local admin/testing flows can cut over without losing project metadata mid-process.
 
 ## Endpoints
 
@@ -248,8 +257,9 @@ curl -X POST http://127.0.0.1:5071/api/projects \
 ```
 
 **Current behavior:**
-- Projects stored **in-memory** (lost on broker restart).
-- `ProjectRegistryPath` not yet implemented; Phase 2 will add persistent storage.
+- With **Orleans disabled**, projects stay **in-memory** and are lost on broker restart.
+- With **Orleans enabled**, project registrations persist in the Orleans SQLite store and the broker imports any already-seeded Phase 1 in-memory registrations on first access inside the same process.
+- `ProjectRegistryPath` remains a reserved compatibility setting; the durable path now lives in Orleans grain storage.
 
 ## Local Development Workflow
 
@@ -392,18 +402,17 @@ Or inline:
 Broker__ListenUrl="http://localhost:5072" dotnet run
 ```
 
-## Known Limitations (Phase 1)
+## Known Limitations
 
-- **No Persistent Project Registry:** Projects are lost when broker restarts. Use registration API or AppHost to re-register.
 - **Single Session Per Project:** Multi-concurrent sessions per project not supported; deferred to Phase 2.
 - **In-Memory Relay Only:** Without Web PubSub, session data is not routed to remote clients.
 - **Windows ConPTY Only:** POSIX TTY (Linux/macOS) support deferred.
 - **No Graceful Shutdown:** Ctrl+C stops immediately; process cleanup is basic. Full shutdown flow planned for Phase 3.
-- **Orleans Disabled:** Grain-based orchestration not ready; in-memory session state used.
+- **Mode Toggle Requires Session Restart:** Durable project/session metadata does not revive live PTY transports. Restart active sessions after switching `Orleans:Enabled`.
 
 ## Next Steps
 
-- **Phase 2:** Persistent project registry, multi-session support, Orleans integration.
+- **Phase 2:** Multi-session support, reconnect/liveness hardening, and broader grain validation.
 - **Phase 3:** Graceful shutdown, advanced observability, POSIX TTY support.
 - **Phase 4:** Windows Service / systemd deployment, advanced scaling.
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -51,6 +51,8 @@ curl -X POST http://127.0.0.1:5071/api/projects \
 curl http://127.0.0.1:5071/api/projects
 ```
 
+> If you launch with `Orleans__Enabled=true`, project registrations and session replay metadata persist in the broker's Orleans SQLite store. Live PTY sessions are still broker-owned, so restart active sessions after switching Orleans mode.
+
 ## Troubleshooting Quick Fixes
 
 | Problem | Fix |

--- a/src/SquadScout.Broker/Orleans/IProjectGrain.cs
+++ b/src/SquadScout.Broker/Orleans/IProjectGrain.cs
@@ -1,0 +1,27 @@
+using Orleans;
+
+namespace SquadScout.Broker.Orleans;
+
+public interface IProjectGrain : IGrainWithStringKey
+{
+    Task<RegisteredProjectRecord?> GetAsync();
+
+    Task<RegisteredProjectRecord> UpsertAsync(RegisteredProjectRecord project);
+}
+
+public interface IProjectGrainFactory
+{
+    IProjectGrain GetGrain(string projectId);
+}
+
+public sealed class OrleansProjectGrainFactory : IProjectGrainFactory
+{
+    private readonly IGrainFactory _grainFactory;
+
+    public OrleansProjectGrainFactory(IGrainFactory grainFactory)
+    {
+        _grainFactory = grainFactory ?? throw new ArgumentNullException(nameof(grainFactory));
+    }
+
+    public IProjectGrain GetGrain(string projectId) => _grainFactory.GetGrain<IProjectGrain>(projectId);
+}

--- a/src/SquadScout.Broker/Orleans/IProjectRegistryGrain.cs
+++ b/src/SquadScout.Broker/Orleans/IProjectRegistryGrain.cs
@@ -1,0 +1,30 @@
+using Orleans;
+
+namespace SquadScout.Broker.Orleans;
+
+public interface IProjectRegistryGrain : IGrainWithStringKey
+{
+    Task<ProjectRegistrySnapshotRecord> GetAsync();
+
+    Task UpsertAsync(RegisteredProjectRecord project);
+
+    Task ImportPhase1SeedAsync(List<RegisteredProjectRecord> projects, DateTimeOffset importedAtUtc);
+}
+
+public interface IProjectRegistryGrainFactory
+{
+    IProjectRegistryGrain GetGrain();
+}
+
+public sealed class OrleansProjectRegistryGrainFactory : IProjectRegistryGrainFactory
+{
+    private const string RegistryGrainKey = "projects";
+    private readonly IGrainFactory _grainFactory;
+
+    public OrleansProjectRegistryGrainFactory(IGrainFactory grainFactory)
+    {
+        _grainFactory = grainFactory ?? throw new ArgumentNullException(nameof(grainFactory));
+    }
+
+    public IProjectRegistryGrain GetGrain() => _grainFactory.GetGrain<IProjectRegistryGrain>(RegistryGrainKey);
+}

--- a/src/SquadScout.Broker/Orleans/OrleansHostStatusSnapshot.cs
+++ b/src/SquadScout.Broker/Orleans/OrleansHostStatusSnapshot.cs
@@ -10,6 +10,8 @@ public sealed class OrleansHostStatusSnapshot
 
     public string SessionStateMode { get; init; } = "in-memory";
 
+    public string ProjectStateMode { get; init; } = "in-memory";
+
     public string ClusterId { get; init; } = string.Empty;
 
     public string ServiceId { get; init; } = string.Empty;
@@ -40,6 +42,7 @@ public sealed class OrleansHostStatusSnapshot
             Enabled = false,
             HostMode = "disabled",
             SessionStateMode = "in-memory",
+            ProjectStateMode = "in-memory",
             ClusterId = options.ClusterId,
             ServiceId = options.ServiceId,
             SiloPort = options.SiloPort,
@@ -50,7 +53,7 @@ public sealed class OrleansHostStatusSnapshot
             SchemaCreatedThisRun = false,
             CompatibilityShimApplied = false,
             Summary = "Orleans is disabled. Broker sessions and projects stay on the Phase 1 in-memory path.",
-            Note = "Set Orleans:Enabled=true to start a local silo and bootstrap SQLite without switching session/project ownership yet."
+            Note = "Set Orleans:Enabled=true to move project registrations and session metadata into durable grains. Live PTY ownership remains on the broker runtime path."
         };
 
     public static OrleansHostStatusSnapshot BootstrapOnly(
@@ -62,6 +65,7 @@ public sealed class OrleansHostStatusSnapshot
             Enabled = true,
             HostMode = "bootstrap-only",
             SessionStateMode = "in-memory",
+            ProjectStateMode = "in-memory",
             ClusterId = options.ClusterId,
             ServiceId = options.ServiceId,
             SiloPort = options.SiloPort,
@@ -85,6 +89,7 @@ public sealed class OrleansHostStatusSnapshot
             Enabled = true,
             HostMode = "session-grains",
             SessionStateMode = "durable-grain",
+            ProjectStateMode = "in-memory",
             ClusterId = options.ClusterId,
             ServiceId = options.ServiceId,
             SiloPort = options.SiloPort,
@@ -97,5 +102,29 @@ public sealed class OrleansHostStatusSnapshot
             CompatibilityShimApplied = compatibilityResult.Applied,
             Summary = "Local Orleans silo owns durable session replay state. Project ownership and transport hosting stay on the broker runtime path until the remaining grain migrations land.",
             Note = compatibilityResult.Note
+        };
+
+    public static OrleansHostStatusSnapshot SessionProjectGrains(
+        OrleansHostOptions options,
+        OrleansSchemaBootstrapResult bootstrapResult,
+        OrleansSqliteCompatibilityResult compatibilityResult) =>
+        new()
+        {
+            Enabled = true,
+            HostMode = "session-project-grains",
+            SessionStateMode = "durable-grain",
+            ProjectStateMode = "durable-grain",
+            ClusterId = options.ClusterId,
+            ServiceId = options.ServiceId,
+            SiloPort = options.SiloPort,
+            GatewayPort = options.GatewayPort,
+            StorageProvider = options.StorageProvider,
+            Invariant = bootstrapResult.Invariant,
+            DatabasePath = bootstrapResult.DatabasePath,
+            SchemaReady = bootstrapResult.SchemaReady,
+            SchemaCreatedThisRun = bootstrapResult.SchemaCreatedThisRun,
+            CompatibilityShimApplied = compatibilityResult.Applied,
+            Summary = "Local Orleans silo owns durable session replay state and the project registration catalog. Session grains keep project ids attached to the durable project catalog while PTY transport ownership stays in the broker runtime path.",
+            Note = $"{compatibilityResult.Note} Running PTY sessions are not revived by the durable metadata cutover; drain or restart active sessions before toggling Orleans mode."
         };
 }

--- a/src/SquadScout.Broker/Orleans/ProjectGrain.cs
+++ b/src/SquadScout.Broker/Orleans/ProjectGrain.cs
@@ -5,6 +5,7 @@ namespace SquadScout.Broker.Orleans;
 public sealed class ProjectGrain : Grain, IProjectGrain
 {
     private readonly IPersistentState<ProjectGrainState> _persistentState;
+    private readonly Func<string>? _projectIdProvider;
     private readonly object _loadGateSync = new();
     private LoadGateState _loadGate = new();
     private RegisteredProjectRecord? _project;
@@ -13,9 +14,11 @@ public sealed class ProjectGrain : Grain, IProjectGrain
 
     public ProjectGrain(
         [PersistentState("project", Configuration.OrleansHostOptions.DefaultStorageProvider)]
-        IPersistentState<ProjectGrainState> persistentState)
+        IPersistentState<ProjectGrainState> persistentState,
+        Func<string>? projectIdProvider = null)
     {
         _persistentState = persistentState ?? throw new ArgumentNullException(nameof(persistentState));
+        _projectIdProvider = projectIdProvider;
     }
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
@@ -48,6 +51,12 @@ public sealed class ProjectGrain : Grain, IProjectGrain
         if (string.IsNullOrWhiteSpace(project.ProjectId))
         {
             throw new ArgumentException("A project id is required.", nameof(project));
+        }
+
+        var grainKey = _projectIdProvider?.Invoke() ?? this.GetPrimaryKeyString();
+        if (!string.Equals(project.ProjectId, grainKey, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("Project id does not match the targeted project grain.", nameof(project));
         }
 
         _project = project.Clone();

--- a/src/SquadScout.Broker/Orleans/ProjectGrain.cs
+++ b/src/SquadScout.Broker/Orleans/ProjectGrain.cs
@@ -1,0 +1,150 @@
+using Orleans.Runtime;
+
+namespace SquadScout.Broker.Orleans;
+
+public sealed class ProjectGrain : Grain, IProjectGrain
+{
+    private readonly IPersistentState<ProjectGrainState> _persistentState;
+    private readonly object _loadGateSync = new();
+    private LoadGateState _loadGate = new();
+    private RegisteredProjectRecord? _project;
+    private volatile bool _isDeactivating;
+    private volatile bool _stateLoaded;
+
+    public ProjectGrain(
+        [PersistentState("project", Configuration.OrleansHostOptions.DefaultStorageProvider)]
+        IPersistentState<ProjectGrainState> persistentState)
+    {
+        _persistentState = persistentState ?? throw new ArgumentNullException(nameof(persistentState));
+    }
+
+    public override async Task OnActivateAsync(CancellationToken cancellationToken)
+    {
+        _isDeactivating = false;
+        await EnsureStateLoadedAsync().ConfigureAwait(true);
+        await base.OnActivateAsync(cancellationToken).ConfigureAwait(true);
+    }
+
+    public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+    {
+        _isDeactivating = true;
+        _project = null;
+        _stateLoaded = false;
+        RetireLoadGate();
+        return base.OnDeactivateAsync(reason, cancellationToken);
+    }
+
+    public async Task<RegisteredProjectRecord?> GetAsync()
+    {
+        await EnsureStateLoadedAsync().ConfigureAwait(true);
+        return _project?.Clone();
+    }
+
+    public async Task<RegisteredProjectRecord> UpsertAsync(RegisteredProjectRecord project)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        await EnsureStateLoadedAsync().ConfigureAwait(true);
+
+        if (string.IsNullOrWhiteSpace(project.ProjectId))
+        {
+            throw new ArgumentException("A project id is required.", nameof(project));
+        }
+
+        _project = project.Clone();
+        await PersistAsync().ConfigureAwait(true);
+        return _project.Clone();
+    }
+
+    private async Task PersistAsync()
+    {
+        if (_project is null)
+        {
+            _persistentState.State = new ProjectGrainState();
+            await _persistentState.ClearStateAsync().ConfigureAwait(true);
+            return;
+        }
+
+        _persistentState.State = new ProjectGrainState
+        {
+            Project = _project.Clone()
+        };
+        await _persistentState.WriteStateAsync().ConfigureAwait(true);
+    }
+
+    private async Task EnsureStateLoadedAsync()
+    {
+        if (_stateLoaded || _isDeactivating)
+        {
+            return;
+        }
+
+        var loadGate = RentLoadGate();
+        await loadGate.Semaphore.WaitAsync().ConfigureAwait(true);
+        try
+        {
+            if (_stateLoaded || _isDeactivating || loadGate.IsRetired)
+            {
+                return;
+            }
+
+            await _persistentState.ReadStateAsync().ConfigureAwait(true);
+            _project = _persistentState.RecordExists
+                ? _persistentState.State.Project?.Clone()
+                : null;
+            _stateLoaded = true;
+        }
+        finally
+        {
+            loadGate.Semaphore.Release();
+            ReleaseLoadGateLease(loadGate);
+        }
+    }
+
+    private LoadGateState RentLoadGate()
+    {
+        lock (_loadGateSync)
+        {
+            _loadGate.LeaseCount++;
+            return _loadGate;
+        }
+    }
+
+    private void RetireLoadGate()
+    {
+        lock (_loadGateSync)
+        {
+            var retiredGate = _loadGate;
+            retiredGate.IsRetired = true;
+            _loadGate = new LoadGateState();
+            TryDisposeRetiredLoadGate(retiredGate);
+        }
+    }
+
+    private void ReleaseLoadGateLease(LoadGateState loadGate)
+    {
+        lock (_loadGateSync)
+        {
+            loadGate.LeaseCount--;
+            TryDisposeRetiredLoadGate(loadGate);
+        }
+    }
+
+    private static void TryDisposeRetiredLoadGate(LoadGateState loadGate)
+    {
+        if (!loadGate.IsRetired || loadGate.LeaseCount != 0)
+        {
+            return;
+        }
+
+        loadGate.Semaphore.Dispose();
+    }
+
+    private sealed class LoadGateState
+    {
+        public SemaphoreSlim Semaphore { get; } = new(1, 1);
+
+        public int LeaseCount { get; set; }
+
+        public bool IsRetired { get; set; }
+    }
+}

--- a/src/SquadScout.Broker/Orleans/ProjectGrainModels.cs
+++ b/src/SquadScout.Broker/Orleans/ProjectGrainModels.cs
@@ -1,0 +1,93 @@
+using Orleans;
+using SquadScout.Contracts.Projects;
+
+namespace SquadScout.Broker.Orleans;
+
+[GenerateSerializer]
+public sealed class RegisteredProjectRecord
+{
+    [Id(0)]
+    public string ProjectId { get; set; } = string.Empty;
+
+    [Id(1)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [Id(2)]
+    public string RepositoryRoot { get; set; } = string.Empty;
+}
+
+[GenerateSerializer]
+public sealed class ProjectGrainState
+{
+    [Id(0)]
+    public RegisteredProjectRecord? Project { get; set; }
+}
+
+[GenerateSerializer]
+public sealed class ProjectRegistrySnapshotRecord
+{
+    [Id(0)]
+    public List<RegisteredProjectRecord> Projects { get; set; } = [];
+
+    [Id(1)]
+    public bool Phase1SeedImported { get; set; }
+
+    [Id(2)]
+    public DateTimeOffset? Phase1SeedImportedAtUtc { get; set; }
+}
+
+[GenerateSerializer]
+public sealed class ProjectRegistryGrainState
+{
+    [Id(0)]
+    public List<RegisteredProjectRecord> Projects { get; set; } = [];
+
+    [Id(1)]
+    public bool Phase1SeedImported { get; set; }
+
+    [Id(2)]
+    public DateTimeOffset? Phase1SeedImportedAtUtc { get; set; }
+}
+
+internal static class ProjectGrainSerialization
+{
+    public static RegisteredProjectRecord ToRecord(this RegisteredProject project) =>
+        new()
+        {
+            ProjectId = project.ProjectId,
+            DisplayName = project.DisplayName,
+            RepositoryRoot = project.RepositoryRoot
+        };
+
+    public static RegisteredProject ToRegisteredProject(this RegisteredProjectRecord project) =>
+        new()
+        {
+            ProjectId = project.ProjectId,
+            DisplayName = project.DisplayName,
+            RepositoryRoot = project.RepositoryRoot
+        };
+
+    public static RegisteredProjectRecord Clone(this RegisteredProjectRecord project) =>
+        new()
+        {
+            ProjectId = project.ProjectId,
+            DisplayName = project.DisplayName,
+            RepositoryRoot = project.RepositoryRoot
+        };
+
+    public static ProjectRegistrySnapshotRecord ToSnapshot(this ProjectRegistryGrainState state) =>
+        new()
+        {
+            Projects = state.Projects.Select(Clone).ToList(),
+            Phase1SeedImported = state.Phase1SeedImported,
+            Phase1SeedImportedAtUtc = state.Phase1SeedImportedAtUtc
+        };
+
+    public static ProjectRegistryGrainState ToState(this ProjectRegistrySnapshotRecord snapshot) =>
+        new()
+        {
+            Projects = snapshot.Projects.Select(Clone).ToList(),
+            Phase1SeedImported = snapshot.Phase1SeedImported,
+            Phase1SeedImportedAtUtc = snapshot.Phase1SeedImportedAtUtc
+        };
+}

--- a/src/SquadScout.Broker/Orleans/ProjectRegistryGrain.cs
+++ b/src/SquadScout.Broker/Orleans/ProjectRegistryGrain.cs
@@ -1,0 +1,182 @@
+using Orleans.Runtime;
+
+namespace SquadScout.Broker.Orleans;
+
+public sealed class ProjectRegistryGrain : Grain, IProjectRegistryGrain
+{
+    private readonly IPersistentState<ProjectRegistryGrainState> _persistentState;
+    private readonly object _loadGateSync = new();
+    private LoadGateState _loadGate = new();
+    private ProjectRegistryGrainState _state = new();
+    private volatile bool _isDeactivating;
+    private volatile bool _stateLoaded;
+
+    public ProjectRegistryGrain(
+        [PersistentState("project-registry", Configuration.OrleansHostOptions.DefaultStorageProvider)]
+        IPersistentState<ProjectRegistryGrainState> persistentState)
+    {
+        _persistentState = persistentState ?? throw new ArgumentNullException(nameof(persistentState));
+    }
+
+    public override async Task OnActivateAsync(CancellationToken cancellationToken)
+    {
+        _isDeactivating = false;
+        await EnsureStateLoadedAsync().ConfigureAwait(true);
+        await base.OnActivateAsync(cancellationToken).ConfigureAwait(true);
+    }
+
+    public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+    {
+        _isDeactivating = true;
+        _state = new ProjectRegistryGrainState();
+        _stateLoaded = false;
+        RetireLoadGate();
+        return base.OnDeactivateAsync(reason, cancellationToken);
+    }
+
+    public async Task<ProjectRegistrySnapshotRecord> GetAsync()
+    {
+        await EnsureStateLoadedAsync().ConfigureAwait(true);
+        return _state.ToSnapshot();
+    }
+
+    public async Task UpsertAsync(RegisteredProjectRecord project)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        await EnsureStateLoadedAsync().ConfigureAwait(true);
+
+        UpsertCore(project);
+        await PersistAsync().ConfigureAwait(true);
+    }
+
+    public async Task ImportPhase1SeedAsync(List<RegisteredProjectRecord> projects, DateTimeOffset importedAtUtc)
+    {
+        ArgumentNullException.ThrowIfNull(projects);
+        await EnsureStateLoadedAsync().ConfigureAwait(true);
+
+        foreach (var project in projects)
+        {
+            if (project is null)
+            {
+                continue;
+            }
+
+            UpsertCore(project);
+        }
+
+        _state.Phase1SeedImported = true;
+        _state.Phase1SeedImportedAtUtc ??= importedAtUtc;
+        await PersistAsync().ConfigureAwait(true);
+    }
+
+    private void UpsertCore(RegisteredProjectRecord project)
+    {
+        if (string.IsNullOrWhiteSpace(project.ProjectId))
+        {
+            throw new ArgumentException("A project id is required.", nameof(project));
+        }
+
+        var projects = _state.Projects;
+        var existingIndex = projects.FindIndex(existing =>
+            string.Equals(existing.ProjectId, project.ProjectId, StringComparison.OrdinalIgnoreCase));
+        if (existingIndex >= 0)
+        {
+            projects[existingIndex] = project.Clone();
+        }
+        else
+        {
+            projects.Add(project.Clone());
+        }
+
+        projects.Sort(static (left, right) =>
+        {
+            var displayNameComparison = StringComparer.OrdinalIgnoreCase.Compare(left.DisplayName, right.DisplayName);
+            return displayNameComparison != 0
+                ? displayNameComparison
+                : StringComparer.OrdinalIgnoreCase.Compare(left.ProjectId, right.ProjectId);
+        });
+    }
+
+    private Task PersistAsync()
+    {
+        _persistentState.State = _state.ToSnapshot().ToState();
+        return _persistentState.WriteStateAsync();
+    }
+
+    private async Task EnsureStateLoadedAsync()
+    {
+        if (_stateLoaded || _isDeactivating)
+        {
+            return;
+        }
+
+        var loadGate = RentLoadGate();
+        await loadGate.Semaphore.WaitAsync().ConfigureAwait(true);
+        try
+        {
+            if (_stateLoaded || _isDeactivating || loadGate.IsRetired)
+            {
+                return;
+            }
+
+            await _persistentState.ReadStateAsync().ConfigureAwait(true);
+            _state = _persistentState.RecordExists
+                ? _persistentState.State.ToSnapshot().ToState()
+                : new ProjectRegistryGrainState();
+            _stateLoaded = true;
+        }
+        finally
+        {
+            loadGate.Semaphore.Release();
+            ReleaseLoadGateLease(loadGate);
+        }
+    }
+
+    private LoadGateState RentLoadGate()
+    {
+        lock (_loadGateSync)
+        {
+            _loadGate.LeaseCount++;
+            return _loadGate;
+        }
+    }
+
+    private void RetireLoadGate()
+    {
+        lock (_loadGateSync)
+        {
+            var retiredGate = _loadGate;
+            retiredGate.IsRetired = true;
+            _loadGate = new LoadGateState();
+            TryDisposeRetiredLoadGate(retiredGate);
+        }
+    }
+
+    private void ReleaseLoadGateLease(LoadGateState loadGate)
+    {
+        lock (_loadGateSync)
+        {
+            loadGate.LeaseCount--;
+            TryDisposeRetiredLoadGate(loadGate);
+        }
+    }
+
+    private static void TryDisposeRetiredLoadGate(LoadGateState loadGate)
+    {
+        if (!loadGate.IsRetired || loadGate.LeaseCount != 0)
+        {
+            return;
+        }
+
+        loadGate.Semaphore.Dispose();
+    }
+
+    private sealed class LoadGateState
+    {
+        public SemaphoreSlim Semaphore { get; } = new(1, 1);
+
+        public int LeaseCount { get; set; }
+
+        public bool IsRetired { get; set; }
+    }
+}

--- a/src/SquadScout.Broker/Program.cs
+++ b/src/SquadScout.Broker/Program.cs
@@ -78,7 +78,7 @@ if (orleansOptions.Enabled)
             });
         }
     });
-    orleansStatus = OrleansHostStatusSnapshot.SessionGrains(orleansOptions, bootstrapResult, compatibilityResult);
+    orleansStatus = OrleansHostStatusSnapshot.SessionProjectGrains(orleansOptions, bootstrapResult, compatibilityResult);
 }
 else
 {
@@ -86,7 +86,7 @@ else
 }
 
 builder.Services.AddSingleton(orleansStatus);
-builder.Services.AddSingleton<IProjectCatalog, InMemoryProjectCatalog>();
+builder.Services.AddSingleton<InMemoryProjectCatalog>();
 builder.Services.AddSingleton<IPtyHost, CopilotPtyHost>();
 builder.Services.AddSingleton<PtySessionEnvelopePump>();
 builder.Services.AddSingleton<ISessionGroupResolver, SessionGroupResolver>();
@@ -108,11 +108,19 @@ builder.Services.AddSingleton<ISessionRelay, InMemorySessionRelay>();
 builder.Services.AddSingleton<ISequenceValidator, SessionSequenceValidator>();
 if (orleansOptions.Enabled)
 {
+    builder.Services.AddSingleton<IProjectGrainFactory, OrleansProjectGrainFactory>();
+    builder.Services.AddSingleton<IProjectRegistryGrainFactory, OrleansProjectRegistryGrainFactory>();
+    builder.Services.AddSingleton<IProjectCatalog>(serviceProvider =>
+        new GrainBackedProjectCatalog(
+            serviceProvider.GetRequiredService<IProjectGrainFactory>(),
+            serviceProvider.GetRequiredService<IProjectRegistryGrainFactory>(),
+            serviceProvider.GetRequiredService<InMemoryProjectCatalog>()));
     builder.Services.AddSingleton<ISessionGrainFactory, OrleansSessionGrainFactory>();
     builder.Services.AddSingleton<ISessionOrchestrator, GrainBackedSessionOrchestrator>();
 }
 else
 {
+    builder.Services.AddSingleton<IProjectCatalog>(serviceProvider => serviceProvider.GetRequiredService<InMemoryProjectCatalog>());
     builder.Services.AddSingleton<ISessionOrchestrator, InMemorySessionOrchestrator>();
 }
 builder.Services.AddSingleton<BrokerControlMessageHandler>();
@@ -139,6 +147,7 @@ app.MapGet("/", (OrleansHostStatusSnapshot status) => Results.Ok(new
     {
         hostMode = status.HostMode,
         sessionStateMode = status.SessionStateMode,
+        projectStateMode = status.ProjectStateMode,
         summary = status.Summary
     }
 }));

--- a/src/SquadScout.Broker/Projects/GrainBackedProjectCatalog.cs
+++ b/src/SquadScout.Broker/Projects/GrainBackedProjectCatalog.cs
@@ -1,0 +1,123 @@
+using SquadScout.Broker.Orleans;
+using SquadScout.Contracts.Projects;
+
+namespace SquadScout.Broker.Projects;
+
+public sealed class GrainBackedProjectCatalog : IProjectCatalog
+{
+    private readonly IProjectGrainFactory _projectGrainFactory;
+    private readonly IProjectRegistryGrainFactory _projectRegistryGrainFactory;
+    private readonly InMemoryProjectCatalog _phase1Catalog;
+    private readonly SemaphoreSlim _phase1SeedGate = new(1, 1);
+    private volatile bool _phase1SeedImported;
+
+    public GrainBackedProjectCatalog(
+        IProjectGrainFactory projectGrainFactory,
+        IProjectRegistryGrainFactory projectRegistryGrainFactory,
+        InMemoryProjectCatalog phase1Catalog)
+    {
+        _projectGrainFactory = projectGrainFactory ?? throw new ArgumentNullException(nameof(projectGrainFactory));
+        _projectRegistryGrainFactory = projectRegistryGrainFactory ?? throw new ArgumentNullException(nameof(projectRegistryGrainFactory));
+        _phase1Catalog = phase1Catalog ?? throw new ArgumentNullException(nameof(phase1Catalog));
+    }
+
+    public async Task<RegisteredProject?> GetAsync(string projectId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(projectId))
+        {
+            throw new ArgumentException("A project id is required.", nameof(projectId));
+        }
+
+        await EnsurePhase1SeedImportedAsync(cancellationToken).ConfigureAwait(false);
+
+        var storedProject = await _projectGrainFactory.GetGrain(projectId).GetAsync().ConfigureAwait(false);
+        if (storedProject is not null)
+        {
+            return storedProject.ToRegisteredProject();
+        }
+
+        var legacyProject = await _phase1Catalog.GetAsync(projectId, cancellationToken).ConfigureAwait(false);
+        if (legacyProject is null)
+        {
+            return null;
+        }
+
+        return (await UpsertDurableAsync(legacyProject.ToRecord()).ConfigureAwait(false)).ToRegisteredProject();
+    }
+
+    public async Task<IReadOnlyCollection<RegisteredProject>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await EnsurePhase1SeedImportedAsync(cancellationToken).ConfigureAwait(false);
+
+        var snapshot = await _projectRegistryGrainFactory.GetGrain().GetAsync().ConfigureAwait(false);
+        return snapshot.Projects
+            .OrderBy(project => project.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(project => project.ProjectId, StringComparer.OrdinalIgnoreCase)
+            .Select(project => project.ToRegisteredProject())
+            .ToArray();
+    }
+
+    public async Task UpsertAsync(RegisteredProject project, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(project);
+
+        await EnsurePhase1SeedImportedAsync(cancellationToken).ConfigureAwait(false);
+        await _phase1Catalog.UpsertAsync(project, cancellationToken).ConfigureAwait(false);
+        await UpsertDurableAsync(project.ToRecord()).ConfigureAwait(false);
+    }
+
+    private async Task EnsurePhase1SeedImportedAsync(CancellationToken cancellationToken)
+    {
+        if (_phase1SeedImported)
+        {
+            return;
+        }
+
+        await _phase1SeedGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_phase1SeedImported)
+            {
+                return;
+            }
+
+            var phase1Projects = (await _phase1Catalog.ListAsync(cancellationToken).ConfigureAwait(false)).ToArray();
+            if (phase1Projects.Length > 0)
+            {
+                var importedAtUtc = DateTimeOffset.UtcNow;
+                var projectRecords = phase1Projects.Select(project => project.ToRecord()).ToList();
+                foreach (var projectRecord in projectRecords)
+                {
+                    await _projectGrainFactory.GetGrain(projectRecord.ProjectId)
+                        .UpsertAsync(projectRecord)
+                        .ConfigureAwait(false);
+                }
+
+                await _projectRegistryGrainFactory.GetGrain()
+                    .ImportPhase1SeedAsync(projectRecords, importedAtUtc)
+                    .ConfigureAwait(false);
+            }
+
+            _phase1SeedImported = true;
+        }
+        finally
+        {
+            _phase1SeedGate.Release();
+        }
+    }
+
+    private async Task<RegisteredProjectRecord> UpsertDurableAsync(RegisteredProjectRecord project)
+    {
+        var storedProject = await _projectGrainFactory.GetGrain(project.ProjectId)
+            .UpsertAsync(project)
+            .ConfigureAwait(false);
+        await _projectRegistryGrainFactory.GetGrain()
+            .UpsertAsync(storedProject)
+            .ConfigureAwait(false);
+        return storedProject;
+    }
+}

--- a/tests/SquadScout.Broker.Tests/BrokerOrleansBootstrapTests.cs
+++ b/tests/SquadScout.Broker.Tests/BrokerOrleansBootstrapTests.cs
@@ -23,6 +23,7 @@ public sealed class BrokerOrleansBootstrapTests
         Assert.False(status!.Enabled);
         Assert.Equal("disabled", status.HostMode);
         Assert.Equal("in-memory", status.SessionStateMode);
+        Assert.Equal("in-memory", status.ProjectStateMode);
         Assert.False(status.SchemaReady);
         Assert.Contains("Phase 1", status.Summary, StringComparison.OrdinalIgnoreCase);
     }
@@ -61,6 +62,7 @@ public sealed class BrokerOrleansBootstrapTests
         Assert.True(snapshot.Enabled);
         Assert.Equal("bootstrap-only", snapshot.HostMode);
         Assert.Equal("in-memory", snapshot.SessionStateMode);
+        Assert.Equal("in-memory", snapshot.ProjectStateMode);
         Assert.True(snapshot.SchemaReady);
         Assert.True(snapshot.SchemaCreatedThisRun);
         Assert.True(snapshot.CompatibilityShimApplied);

--- a/tests/SquadScout.Broker.Tests/OrleansSessionGrainTests.cs
+++ b/tests/SquadScout.Broker.Tests/OrleansSessionGrainTests.cs
@@ -50,7 +50,45 @@ public sealed class OrleansSessionGrainTests
         Assert.True(snapshot.Enabled);
         Assert.Equal("session-grains", snapshot.HostMode);
         Assert.Equal("durable-grain", snapshot.SessionStateMode);
+        Assert.Equal("in-memory", snapshot.ProjectStateMode);
         Assert.Contains("durable session replay state", snapshot.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SessionProjectGrainStatusSnapshotReportsDurableProjectMode()
+    {
+        var snapshot = OrleansHostStatusSnapshot.SessionProjectGrains(
+            new OrleansHostOptions
+            {
+                Enabled = true,
+                ClusterId = "test-cluster",
+                ServiceId = "test-service",
+                SiloPort = 11111,
+                GatewayPort = 30000,
+                StorageProvider = OrleansHostOptions.DefaultStorageProvider,
+                AdoNetInvariant = OrleansHostOptions.DefaultAdoNetInvariant
+            },
+            new OrleansSchemaBootstrapResult
+            {
+                ConnectionString = "Data Source=.squadscout\\orleans\\tests.db;Mode=ReadWriteCreate;Cache=Shared",
+                Invariant = OrleansHostOptions.DefaultAdoNetInvariant,
+                DatabasePath = "D:\\GitHub\\SquadScout-20\\.squadscout\\orleans\\tests.db",
+                SchemaReady = true,
+                SchemaCreatedThisRun = false
+            },
+            new OrleansSqliteCompatibilityResult
+            {
+                ConfiguredInvariant = OrleansHostOptions.DefaultAdoNetInvariant,
+                Applied = true,
+                Note = "SQLite compatibility shim applied."
+            });
+
+        Assert.True(snapshot.Enabled);
+        Assert.Equal("session-project-grains", snapshot.HostMode);
+        Assert.Equal("durable-grain", snapshot.SessionStateMode);
+        Assert.Equal("durable-grain", snapshot.ProjectStateMode);
+        Assert.Contains("project registration catalog", snapshot.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("restart active sessions", snapshot.Note, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -242,7 +280,7 @@ public sealed class OrleansSessionGrainTests
                 await releaseFirstMessage.Task.ConfigureAwait(true);
             });
 
-        await firstAcceptedEntered.Task.ConfigureAwait(false);
+        await firstAcceptedEntered.Task;
 
         await orchestrator.RecordBrokerMessageAsync(
             session.SessionId,
@@ -290,13 +328,17 @@ public sealed class OrleansSessionGrainTests
     [Fact]
     public async Task RelayPipelineRemainsCompatibleWithGrainBackedSessionState()
     {
-        var projectCatalog = new InMemoryProjectCatalog();
-        await projectCatalog.UpsertAsync(new RegisteredProject
+        var phase1ProjectCatalog = new InMemoryProjectCatalog();
+        await phase1ProjectCatalog.UpsertAsync(new RegisteredProject
         {
             ProjectId = "broker",
             DisplayName = "Broker",
             RepositoryRoot = GetRepositoryRoot()
         });
+        var projectCatalog = new GrainBackedProjectCatalog(
+            new TestProjectGrainFactory(),
+            new TestProjectRegistryGrainFactory(),
+            phase1ProjectCatalog);
 
         var relayPublisher = new RecordingRelayPublisher();
         var orchestrator = new GrainBackedSessionOrchestrator(relayPublisher, new TestSessionGrainFactory());
@@ -342,6 +384,43 @@ public sealed class OrleansSessionGrainTests
             message => Assert.Equal(SessionMessageType.SessionLifecycle, message.MessageType),
             message => Assert.Equal(SessionMessageType.Output, message.MessageType),
             message => Assert.Equal(SessionMessageType.SessionLifecycle, message.MessageType));
+    }
+
+    [Fact]
+    public async Task GrainBackedProjectCatalogImportsPhase1ProjectsAndPersistsAcrossReactivation()
+    {
+        var phase1Catalog = new InMemoryProjectCatalog();
+        await phase1Catalog.UpsertAsync(new RegisteredProject
+        {
+            ProjectId = "broker",
+            DisplayName = "Broker",
+            RepositoryRoot = GetRepositoryRoot()
+        });
+
+        var projectGrainFactory = new TestProjectGrainFactory();
+        var projectRegistryGrainFactory = new TestProjectRegistryGrainFactory();
+        var firstCatalog = new GrainBackedProjectCatalog(projectGrainFactory, projectRegistryGrainFactory, phase1Catalog);
+
+        var importedProject = await firstCatalog.GetAsync("broker");
+        await firstCatalog.UpsertAsync(new RegisteredProject
+        {
+            ProjectId = "mobile",
+            DisplayName = "Mobile",
+            RepositoryRoot = GetRepositoryRoot()
+        });
+
+        var secondCatalog = new GrainBackedProjectCatalog(
+            projectGrainFactory,
+            projectRegistryGrainFactory,
+            new InMemoryProjectCatalog());
+        var persistedProjects = await secondCatalog.ListAsync();
+
+        Assert.NotNull(importedProject);
+        Assert.Equal("broker", importedProject!.ProjectId);
+        Assert.Collection(
+            persistedProjects.OrderBy(project => project.DisplayName, StringComparer.OrdinalIgnoreCase),
+            project => Assert.Equal("broker", project.ProjectId),
+            project => Assert.Equal("mobile", project.ProjectId));
     }
 
     private static BrokerEnvelopeCommand<TPayload> CreateBrokerCommand<TPayload>(
@@ -420,6 +499,14 @@ public sealed class OrleansSessionGrainTests
         return gates.Count;
     }
 
+    private static RegisteredProjectRecord CloneProject(RegisteredProjectRecord source) =>
+        new()
+        {
+            ProjectId = source.ProjectId,
+            DisplayName = source.DisplayName,
+            RepositoryRoot = source.RepositoryRoot
+        };
+
     private sealed class TestSessionGrainFactory : ISessionGrainFactory
     {
         private readonly ConcurrentDictionary<string, TestPersistentState> _states = new(StringComparer.OrdinalIgnoreCase);
@@ -429,6 +516,24 @@ public sealed class OrleansSessionGrainTests
             var persistentState = _states.GetOrAdd(sessionId, static _ => new TestPersistentState());
             return new SessionGrain(persistentState);
         }
+    }
+
+    private sealed class TestProjectGrainFactory : IProjectGrainFactory
+    {
+        private readonly ConcurrentDictionary<string, TestProjectPersistentState> _states = new(StringComparer.OrdinalIgnoreCase);
+
+        public IProjectGrain GetGrain(string projectId)
+        {
+            var persistentState = _states.GetOrAdd(projectId, static _ => new TestProjectPersistentState());
+            return new ProjectGrain(persistentState);
+        }
+    }
+
+    private sealed class TestProjectRegistryGrainFactory : IProjectRegistryGrainFactory
+    {
+        private readonly TestProjectRegistryPersistentState _persistentState = new();
+
+        public IProjectRegistryGrain GetGrain() => new ProjectRegistryGrain(_persistentState);
     }
 
     private sealed class TestPersistentState : IPersistentState<SessionGrainState>
@@ -587,6 +692,154 @@ public sealed class OrleansSessionGrainTests
                 HasMore = source.HasMore,
                 IsComplete = source.IsComplete,
                 Reason = source.Reason
+            };
+    }
+
+    private sealed class TestProjectPersistentState : IPersistentState<ProjectGrainState>
+    {
+        private readonly object _syncRoot = new();
+        private ProjectGrainState _storedState = new();
+        private bool _recordExists;
+
+        public string Etag { get; set; } = string.Empty;
+
+        public bool RecordExists
+        {
+            get
+            {
+                lock (_syncRoot)
+                {
+                    return _recordExists;
+                }
+            }
+        }
+
+        public ProjectGrainState State { get; set; } = new();
+
+        public Task ClearStateAsync() => ClearStateAsync(CancellationToken.None);
+
+        public Task ClearStateAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_syncRoot)
+            {
+                _storedState = new ProjectGrainState();
+                State = new ProjectGrainState();
+                _recordExists = false;
+                Etag = string.Empty;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task ReadStateAsync() => ReadStateAsync(CancellationToken.None);
+
+        public Task ReadStateAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_syncRoot)
+            {
+                State = Clone(_storedState);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task WriteStateAsync() => WriteStateAsync(CancellationToken.None);
+
+        public Task WriteStateAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_syncRoot)
+            {
+                _storedState = Clone(State);
+                _recordExists = true;
+                Etag = Guid.NewGuid().ToString("n");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static ProjectGrainState Clone(ProjectGrainState source) =>
+            new()
+            {
+                Project = source.Project is null
+                    ? null
+                    : CloneProject(source.Project)
+            };
+    }
+
+    private sealed class TestProjectRegistryPersistentState : IPersistentState<ProjectRegistryGrainState>
+    {
+        private readonly object _syncRoot = new();
+        private ProjectRegistryGrainState _storedState = new();
+        private bool _recordExists;
+
+        public string Etag { get; set; } = string.Empty;
+
+        public bool RecordExists
+        {
+            get
+            {
+                lock (_syncRoot)
+                {
+                    return _recordExists;
+                }
+            }
+        }
+
+        public ProjectRegistryGrainState State { get; set; } = new();
+
+        public Task ClearStateAsync() => ClearStateAsync(CancellationToken.None);
+
+        public Task ClearStateAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_syncRoot)
+            {
+                _storedState = new ProjectRegistryGrainState();
+                State = new ProjectRegistryGrainState();
+                _recordExists = false;
+                Etag = string.Empty;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task ReadStateAsync() => ReadStateAsync(CancellationToken.None);
+
+        public Task ReadStateAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_syncRoot)
+            {
+                State = Clone(_storedState);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task WriteStateAsync() => WriteStateAsync(CancellationToken.None);
+
+        public Task WriteStateAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_syncRoot)
+            {
+                _storedState = Clone(State);
+                _recordExists = true;
+                Etag = Guid.NewGuid().ToString("n");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static ProjectRegistryGrainState Clone(ProjectRegistryGrainState source) =>
+            new()
+            {
+                Projects = source.Projects.Select(CloneProject).ToList(),
+                Phase1SeedImported = source.Phase1SeedImported,
+                Phase1SeedImportedAtUtc = source.Phase1SeedImportedAtUtc
             };
     }
 }

--- a/tests/SquadScout.Broker.Tests/OrleansSessionGrainTests.cs
+++ b/tests/SquadScout.Broker.Tests/OrleansSessionGrainTests.cs
@@ -423,6 +423,21 @@ public sealed class OrleansSessionGrainTests
             project => Assert.Equal("mobile", project.ProjectId));
     }
 
+    [Fact]
+    public async Task ProjectGrainRejectsMismatchedProjectIdentifier()
+    {
+        var projectGrain = new TestProjectGrainFactory().GetGrain("broker");
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => projectGrain.UpsertAsync(new RegisteredProjectRecord
+        {
+            ProjectId = "mobile",
+            DisplayName = "Mobile",
+            RepositoryRoot = GetRepositoryRoot()
+        }));
+
+        Assert.Equal("project", exception.ParamName);
+    }
+
     private static BrokerEnvelopeCommand<TPayload> CreateBrokerCommand<TPayload>(
         SessionMessageType messageType,
         string messageId,
@@ -525,7 +540,7 @@ public sealed class OrleansSessionGrainTests
         public IProjectGrain GetGrain(string projectId)
         {
             var persistentState = _states.GetOrAdd(projectId, static _ => new TestProjectPersistentState());
-            return new ProjectGrain(persistentState);
+            return new ProjectGrain(persistentState, () => projectId);
         }
     }
 


### PR DESCRIPTION
## Summary
- move broker project registration onto durable Orleans project grains with a persisted registry grain for list/query operations
- keep sessions attached to durable project state by project id while preserving broker-owned PTY transport ownership
- bridge Phase 1 in-memory project registrations into the Orleans-backed catalog on first durable access and document cutover compatibility constraints

## Validation
- dotnet build .\\SquadScout.slnx -nologo
- dotnet test .\\SquadScout.slnx -nologo --no-build
- dotnet run --project .\\src\\SquadScout.Broker\\SquadScout.Broker.csproj --no-build --no-launch-profile -- --Broker:ListenUrl=http://127.0.0.1:5076 --Orleans:Enabled=true smoke: GET /api/orleans/status => hostMode=session-project-grains, projectStateMode=durable-grain, schemaReady=true

Closes #20