### PR TITLE
Implement reconnect replay resume flow

### DIFF
--- a/src/SquadScout.App/MauiProgram.cs
+++ b/src/SquadScout.App/MauiProgram.cs
@@ -49,6 +49,10 @@ public static class MauiProgram
 		builder.Services.AddSingleton<IPubSubNegotiationClient, PubSubNegotiationClient>();
 		builder.Services.AddSingleton<IWebPubSubSocketFactory, ClientWebPubSubSocketFactory>();
 		builder.Services.AddSingleton<IMessageConnectionService, MessagingConnectionService>();
+		builder.Services.AddSingleton<ISessionResumeService>(services =>
+			new SessionResumeService(
+				Path.Combine(FileSystem.Current.AppDataDirectory, "session-resume", "active-session.json"),
+				services.GetRequiredService<IActiveSessionState>()));
 		builder.Services.AddSingleton<BrokerControlChannelClient>();
 		builder.Services.AddSingleton<IProjectCatalogService, WebPubSubProjectCatalogService>();
 		builder.Services.AddSingleton<ISessionLifecycleService, WebPubSubSessionLifecycleService>();

--- a/src/SquadScout.App/Services/MessagingConnectionService.cs
+++ b/src/SquadScout.App/Services/MessagingConnectionService.cs
@@ -98,7 +98,10 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
         }
     }
 
-    public async Task<MessageConnectionStatus> PrepareForSessionAsync(SessionDescriptor session, CancellationToken cancellationToken = default)
+    public async Task<MessageConnectionStatus> PrepareForSessionAsync(
+        SessionDescriptor session,
+        MessageConnectionResumeState? resumeState = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(session);
         cancellationToken.ThrowIfCancellationRequested();
@@ -112,6 +115,11 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
                 await CleanupTransportAsync(cancellationToken).ConfigureAwait(false);
                 SetActiveSession(session);
                 ResetTransportState(clearTraffic: true);
+            }
+
+            if (resumeState is not null)
+            {
+                RestoreBrokerOrderingStateLocked(resumeState);
             }
 
             if (!_messagingOptions.AutoPrepareOnSessionStart)
@@ -131,7 +139,12 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
                 return CurrentStatus;
             }
 
-            return await ConnectCoreAsync(isReconnect: false, reconnectAttempt: 0, cancellationToken).ConfigureAwait(false);
+            return await ConnectCoreAsync(
+                    isReconnect: resumeState is not null,
+                    reconnectAttempt: 0,
+                    cancellationToken,
+                    initialReplayReason: resumeState is not null ? ReplayRequestReason.ClientRecovery : null)
+                .ConfigureAwait(false);
         }
         finally
         {
@@ -255,7 +268,8 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
         CancellationToken cancellationToken,
         PubSubNegotiateResponse? negotiationOverride = null,
         bool publishTransitionStatus = true,
-        string? failureReasonPrefix = null)
+        string? failureReasonPrefix = null,
+        ReplayRequestReason? initialReplayReason = null)
     {
         var session = GetActiveSession()
             ?? throw new InvalidOperationException("An active session is required before live messaging can connect.");
@@ -265,10 +279,12 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
         if (publishTransitionStatus)
         {
             PublishStatus(
-                new MessageConnectionStatus
+                CreateStatusWithOrderingState(new MessageConnectionStatus
                 {
                     State = isReconnect ? MessageConnectionState.Reconnecting : MessageConnectionState.Connecting,
-                    Summary = isReconnect
+                    Summary = initialReplayReason == ReplayRequestReason.ClientRecovery
+                        ? $"Restoring session '{session.SessionId}' from this device."
+                        : isReconnect
                         ? $"Retrying live messaging for session '{session.SessionId}'."
                         : $"Connecting live messaging for session '{session.SessionId}'.",
                     Hub = _messagingOptions.Hub,
@@ -276,7 +292,7 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
                     ProjectId = session.ProjectId,
                     SessionId = session.SessionId,
                     ReconnectAttempt = reconnectAttempt
-                });
+                }));
         }
 
         try
@@ -312,10 +328,12 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
                 _connectionId = connectionId;
             }
 
-            var status = new MessageConnectionStatus
+            var status = CreateStatusWithOrderingState(new MessageConnectionStatus
             {
                 State = MessageConnectionState.Connected,
-                Summary = isReconnect
+                Summary = initialReplayReason == ReplayRequestReason.ClientRecovery
+                    ? $"Resumed live messaging for session '{session.SessionId}' on hub '{negotiation.Hub}'."
+                    : isReconnect
                     ? $"Live messaging reconnected for session '{session.SessionId}' on hub '{negotiation.Hub}'."
                     : $"Live messaging connected for session '{session.SessionId}' on hub '{negotiation.Hub}'.",
                 Hub = negotiation.Hub,
@@ -327,14 +345,14 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
                 ConnectedAtUtc = _utcNow(),
                 RefreshAtUtc = negotiation.RefreshAtUtc,
                 ReconnectAttempt = reconnectAttempt
-            };
+            });
 
             PublishStatus(status);
             ScheduleTokenRefresh(negotiation);
-            if (isReconnect)
+            if (initialReplayReason is not null || isReconnect)
             {
                 await RequestReplayAsync(
-                        ReplayRequestReason.ReconnectResume,
+                        initialReplayReason ?? ReplayRequestReason.ReconnectResume,
                         operationGateHeld: true,
                         cancellationToken)
                     .ConfigureAwait(false);
@@ -571,6 +589,8 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             PublishStatus(CreateReplayGapWarningStatus(envelope.SessionId, payload));
         }
 
+        var replayReason = CurrentStatus.ReplayReason ?? ReplayRequestReason.GapDetected;
+
         foreach (var replayedEnvelope in payload.Messages)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -598,6 +618,17 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
                     ObservedAtUtc = DateTimeOffset.UtcNow,
                     Summary = $"Applied replayed {replayedEnvelope.MessageType} for session '{replayedEnvelope.SessionId}'."
                 });
+        }
+
+        if (payload.HasMore && payload.Messages.Count > 0 && payload.Messages[^1].Sequence is long nextFromExclusive)
+        {
+            QueueReplayRequest(
+                replayReason,
+                cancellationToken,
+                fromSequenceInclusive: nextFromExclusive + 1,
+                toSequenceInclusive: payload.AvailableToSequence,
+                publishReplayStatus: !payload.GapDetected);
+            return true;
         }
 
         if (!payload.GapDetected && !IsGapDetected())
@@ -692,6 +723,20 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
         _replayRequestPending = false;
     }
 
+    private void RestoreBrokerOrderingStateLocked(MessageConnectionResumeState resumeState)
+    {
+        ArgumentNullException.ThrowIfNull(resumeState);
+
+        _currentGeneration = Math.Max(SessionEnvelopeContract.InitialGeneration, resumeState.Generation);
+        _acknowledgedSequence = resumeState.AcknowledgedSequence is > 0 ? resumeState.AcknowledgedSequence : null;
+        _highestObservedBrokerSequence = _acknowledgedSequence;
+        _observedBrokerSequences.Clear();
+        _appliedBrokerSequences.Clear();
+        _appliedReplayResponseMessageIds.Clear();
+        _gapDetected = false;
+        _replayRequestPending = false;
+    }
+
     private readonly record struct BrokerEnvelopeTrackingResult(
         bool ShouldProcess,
         bool ShouldAppend,
@@ -708,7 +753,10 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
     private async Task RequestReplayAsync(
         ReplayRequestReason reason,
         bool operationGateHeld,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        long? fromSequenceInclusive = null,
+        long? toSequenceInclusive = null,
+        bool publishReplayStatus = true)
     {
         if (!operationGateHeld)
         {
@@ -717,10 +765,15 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
 
         try
         {
-            var replayRequest = CreateReplayRequestEnvelope(reason);
+            var replayRequest = CreateReplayRequestEnvelope(reason, fromSequenceInclusive, toSequenceInclusive);
             if (replayRequest is null)
             {
                 return;
+            }
+
+            if (publishReplayStatus)
+            {
+                PublishStatus(CreateReplayPendingStatus(reason, replayRequest.Payload.FromSequenceInclusive));
             }
 
             await SendEnvelopeCoreAsync(replayRequest, requireConnectedStatus: true, cancellationToken).ConfigureAwait(false);
@@ -743,16 +796,38 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
         }
     }
 
-    private void QueueReplayRequest(ReplayRequestReason reason, CancellationToken cancellationToken)
+    private void QueueReplayRequest(
+        ReplayRequestReason reason,
+        CancellationToken cancellationToken,
+        long? fromSequenceInclusive = null,
+        long? toSequenceInclusive = null,
+        bool publishReplayStatus = true)
     {
-        _ = RunReplayRequestAsync(reason, cancellationToken);
+        _ = RunReplayRequestAsync(
+            reason,
+            cancellationToken,
+            fromSequenceInclusive,
+            toSequenceInclusive,
+            publishReplayStatus);
     }
 
-    private async Task RunReplayRequestAsync(ReplayRequestReason reason, CancellationToken cancellationToken)
+    private async Task RunReplayRequestAsync(
+        ReplayRequestReason reason,
+        CancellationToken cancellationToken,
+        long? fromSequenceInclusive = null,
+        long? toSequenceInclusive = null,
+        bool publishReplayStatus = true)
     {
         try
         {
-            await RequestReplayAsync(reason, operationGateHeld: false, cancellationToken).ConfigureAwait(false);
+            await RequestReplayAsync(
+                    reason,
+                    operationGateHeld: false,
+                    cancellationToken,
+                    fromSequenceInclusive,
+                    toSequenceInclusive,
+                    publishReplayStatus)
+                .ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -763,7 +838,10 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
         }
     }
 
-    private MessageEnvelope<ReplayRequestPayload>? CreateReplayRequestEnvelope(ReplayRequestReason reason)
+    private MessageEnvelope<ReplayRequestPayload>? CreateReplayRequestEnvelope(
+        ReplayRequestReason reason,
+        long? fromSequenceInclusive = null,
+        long? toSequenceInclusive = null)
     {
         lock (_stateSync)
         {
@@ -791,7 +869,8 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
                 CorrelationId = $"mobile-session:{_activeSession.SessionId}",
                 Payload = new ReplayRequestPayload
                 {
-                    FromSequenceInclusive = (_acknowledgedSequence ?? 0) + 1,
+                    FromSequenceInclusive = fromSequenceInclusive ?? (_acknowledgedSequence ?? 0) + 1,
+                    ToSequenceInclusive = toSequenceInclusive,
                     Reason = reason
                 }
             };
@@ -1198,7 +1277,7 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
     }
 
     private MessageConnectionStatus CreateReadyStatus(SessionDescriptor session) =>
-        new()
+        CreateStatusWithOrderingState(new MessageConnectionStatus
         {
             State = MessageConnectionState.Ready,
             Summary = $"Live messaging is staged for session '{session.SessionId}'. Use Retry live transport to connect when needed.",
@@ -1206,22 +1285,22 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             SupportsLiveSessionStream = true,
             ProjectId = session.ProjectId,
             SessionId = session.SessionId
-        };
+        });
 
     private MessageConnectionStatus CreateDisconnectedStatus(string? summary = null) =>
-        new()
+        CreateStatusWithOrderingState(new MessageConnectionStatus
         {
             State = MessageConnectionState.Disconnected,
             Summary = summary ?? $"Live messaging is disconnected from hub '{_messagingOptions.Hub}'.",
             Hub = _messagingOptions.Hub,
             SupportsLiveSessionStream = true
-        };
+        });
 
     private MessageConnectionStatus CreateFaultedStatus(
         SessionDescriptor session,
         int reconnectAttempt,
         string failureReason) =>
-        new()
+        CreateStatusWithOrderingState(new MessageConnectionStatus
         {
             State = MessageConnectionState.Faulted,
             Summary = $"Live messaging is unavailable for session '{session.SessionId}'. {failureReason}",
@@ -1233,7 +1312,7 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             RefreshAtUtc = _negotiation?.RefreshAtUtc,
             ReconnectAttempt = reconnectAttempt,
             FailureReason = failureReason
-        };
+        });
 
     private MessageConnectionStatus? TryCreateConnectedStatus()
     {
@@ -1258,9 +1337,42 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
                 ConnectionId = _connectionId,
                 ConnectedAtUtc = _currentStatus.ConnectedAtUtc,
                 RefreshAtUtc = _negotiation.RefreshAtUtc,
-                ReconnectAttempt = _currentStatus.ReconnectAttempt
+                ReconnectAttempt = _currentStatus.ReconnectAttempt,
+                Generation = _currentGeneration,
+                AcknowledgedSequence = _acknowledgedSequence
             };
         }
+    }
+
+    private MessageConnectionStatus CreateReplayPendingStatus(ReplayRequestReason reason, long fromSequenceInclusive)
+    {
+        var connectedStatus = TryCreateConnectedStatus();
+        var session = GetActiveSession();
+        var sessionId = session?.SessionId ?? CurrentStatus.SessionId ?? "the active session";
+        var summary = reason switch
+        {
+            ReplayRequestReason.ClientRecovery =>
+                $"Resuming session '{sessionId}' from this device. Recovering transcript continuity from sequence {fromSequenceInclusive}.",
+            ReplayRequestReason.ReconnectResume =>
+                $"Live messaging reconnected for session '{sessionId}'. Recovering transcript continuity from sequence {fromSequenceInclusive}.",
+            _ =>
+                $"A broker sequence gap was detected for session '{sessionId}'. Recovering messages from sequence {fromSequenceInclusive}."
+        };
+
+        if (connectedStatus is null && session is not null)
+        {
+            connectedStatus = CreateFaultedStatus(session, CurrentStatus.ReconnectAttempt, summary);
+        }
+
+        return (connectedStatus ?? CurrentStatus) with
+        {
+            Summary = summary,
+            IsReplayPending = true,
+            ReplayReason = reason,
+            ReplayFromSequenceInclusive = fromSequenceInclusive,
+            ReplayAvailableFromSequence = null,
+            ReplayAvailableToSequence = null
+        };
     }
 
     private MessageConnectionStatus CreateReplayGapWarningStatus(string sessionId, ReplayResponsePayload payload)
@@ -1283,7 +1395,9 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
         {
             State = MessageConnectionState.Faulted,
             Summary = $"Live messaging replay warning for session '{sessionId}'. {failureReason}",
-            FailureReason = failureReason
+            FailureReason = failureReason,
+            ReplayAvailableFromSequence = payload.AvailableFromSequence,
+            ReplayAvailableToSequence = payload.AvailableToSequence
         };
     }
 
@@ -1334,8 +1448,22 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
         {
             State = MessageConnectionState.Faulted,
             Summary = summary,
-            FailureReason = failureReason
+            FailureReason = failureReason,
+            ReplayAvailableFromSequence = null,
+            ReplayAvailableToSequence = null
         };
+    }
+
+    private MessageConnectionStatus CreateStatusWithOrderingState(MessageConnectionStatus status)
+    {
+        lock (_stateSync)
+        {
+            return status with
+            {
+                Generation = _currentGeneration,
+                AcknowledgedSequence = _acknowledgedSequence
+            };
+        }
     }
 
     private static string ResolveUpstreamEventName(SessionMessageType messageType) =>

--- a/src/SquadScout.App/Services/MessagingConnectionService.cs
+++ b/src/SquadScout.App/Services/MessagingConnectionService.cs
@@ -620,12 +620,16 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
                 });
         }
 
-        if (payload.HasMore && payload.Messages.Count > 0 && payload.Messages[^1].Sequence is long nextFromExclusive)
+        if (payload.HasMore)
         {
+            var nextFromInclusive = payload.Messages.Count > 0 && payload.Messages[^1].Sequence is long nextFromExclusive
+                ? nextFromExclusive + 1
+                : GetNextReplayFromSequence();
+
             QueueReplayRequest(
                 replayReason,
                 cancellationToken,
-                fromSequenceInclusive: nextFromExclusive + 1,
+                fromSequenceInclusive: nextFromInclusive,
                 toSequenceInclusive: payload.AvailableToSequence,
                 publishReplayStatus: !payload.GapDetected);
             return true;
@@ -747,6 +751,14 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
         lock (_stateSync)
         {
             return _gapDetected;
+        }
+    }
+
+    private long GetNextReplayFromSequence()
+    {
+        lock (_stateSync)
+        {
+            return (_acknowledgedSequence ?? 0) + 1;
         }
     }
 

--- a/src/SquadScout.App/Services/ServiceContracts.cs
+++ b/src/SquadScout.App/Services/ServiceContracts.cs
@@ -63,6 +63,20 @@ public sealed record MessageConnectionStatus
     public int ReconnectAttempt { get; init; }
 
     public string? FailureReason { get; init; }
+
+    public long Generation { get; init; } = SessionEnvelopeContract.InitialGeneration;
+
+    public long? AcknowledgedSequence { get; init; }
+
+    public bool IsReplayPending { get; init; }
+
+    public ReplayRequestReason? ReplayReason { get; init; }
+
+    public long? ReplayFromSequenceInclusive { get; init; }
+
+    public long? ReplayAvailableFromSequence { get; init; }
+
+    public long? ReplayAvailableToSequence { get; init; }
 }
 
 public enum MessageTrafficDirection
@@ -99,6 +113,24 @@ public sealed record ActiveSessionSnapshot(
     public bool HasActiveSession => Project is not null && Session is not null;
 }
 
+public sealed record MessageConnectionResumeState
+{
+    public long Generation { get; init; } = SessionEnvelopeContract.InitialGeneration;
+
+    public long? AcknowledgedSequence { get; init; }
+}
+
+public sealed record ActiveSessionResumeState
+{
+    public ActiveSessionSnapshot Snapshot { get; init; } = ActiveSessionSnapshot.Empty;
+
+    public MessageConnectionResumeState Connection { get; init; } = new();
+
+    public IReadOnlyList<MessageEnvelopeTraffic> RecentTraffic { get; init; } = Array.Empty<MessageEnvelopeTraffic>();
+
+    public DateTimeOffset SavedAtUtc { get; init; } = DateTimeOffset.UtcNow;
+}
+
 public interface IAuthenticationService
 {
     Task<ClientIdentity> GetCurrentIdentityAsync(CancellationToken cancellationToken = default);
@@ -114,7 +146,10 @@ public interface IMessageConnectionService
 
     IReadOnlyList<MessageEnvelopeTraffic> RecentTraffic { get; }
 
-    Task<MessageConnectionStatus> PrepareForSessionAsync(SessionDescriptor session, CancellationToken cancellationToken = default);
+    Task<MessageConnectionStatus> PrepareForSessionAsync(
+        SessionDescriptor session,
+        MessageConnectionResumeState? resumeState = null,
+        CancellationToken cancellationToken = default);
 
     Task<MessageConnectionStatus> ReconnectAsync(CancellationToken cancellationToken = default);
 
@@ -123,6 +158,17 @@ public interface IMessageConnectionService
     Task SendEnvelopeAsync<TPayload>(MessageEnvelope<TPayload> envelope, CancellationToken cancellationToken = default);
 
     Task<MessageConnectionStatus> ResetAsync(CancellationToken cancellationToken = default);
+}
+
+public interface ISessionResumeService
+{
+    ActiveSessionResumeState? CurrentState { get; }
+
+    Task RestoreAsync(CancellationToken cancellationToken = default);
+
+    Task SaveAsync(ActiveSessionResumeState state, CancellationToken cancellationToken = default);
+
+    Task ClearAsync(CancellationToken cancellationToken = default);
 }
 
 public interface IProjectCatalogService

--- a/src/SquadScout.App/Services/SessionResumeService.cs
+++ b/src/SquadScout.App/Services/SessionResumeService.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using SquadScout.Contracts.Messages;
+
+namespace SquadScout.App.Services;
+
+public sealed class SessionResumeService : ISessionResumeService
+{
+    private readonly IActiveSessionState _activeSessionState;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly string _storagePath;
+
+    private ActiveSessionResumeState? _currentState;
+    private bool _restored;
+
+    public SessionResumeService(string storagePath, IActiveSessionState activeSessionState)
+    {
+        if (string.IsNullOrWhiteSpace(storagePath))
+        {
+            throw new ArgumentException("A storage path is required.", nameof(storagePath));
+        }
+
+        _storagePath = storagePath;
+        _activeSessionState = activeSessionState ?? throw new ArgumentNullException(nameof(activeSessionState));
+    }
+
+    public ActiveSessionResumeState? CurrentState => _currentState;
+
+    public async Task RestoreAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_restored)
+            {
+                return;
+            }
+
+            _restored = true;
+            _currentState = await ReadStateCoreAsync(cancellationToken).ConfigureAwait(false);
+
+            if (_currentState?.Snapshot is not { HasActiveSession: true, Project: not null, Session: not null } snapshot)
+            {
+                return;
+            }
+
+            var restoredSummary = BuildRestoredSummary(snapshot, _currentState.SavedAtUtc);
+            var restoredSnapshot = snapshot with { Summary = restoredSummary };
+            _currentState = _currentState with { Snapshot = restoredSnapshot };
+            _activeSessionState.SetActiveSession(
+                restoredSnapshot.Project!,
+                restoredSnapshot.Session!,
+                restoredSnapshot.Source,
+                restoredSnapshot.Summary);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task SaveAsync(ActiveSessionResumeState state, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!state.Snapshot.HasActiveSession)
+        {
+            await ClearAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _restored = true;
+            _currentState = state with { SavedAtUtc = DateTimeOffset.UtcNow };
+
+            var directory = Path.GetDirectoryName(_storagePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            await using var stream = File.Create(_storagePath);
+            await JsonSerializer.SerializeAsync(stream, _currentState, SessionMessageSerializer.DefaultOptions, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task ClearAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _restored = true;
+            _currentState = null;
+            if (File.Exists(_storagePath))
+            {
+                File.Delete(_storagePath);
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task<ActiveSessionResumeState?> ReadStateCoreAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_storagePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            await using var stream = File.OpenRead(_storagePath);
+            return await JsonSerializer.DeserializeAsync<ActiveSessionResumeState>(
+                    stream,
+                    SessionMessageSerializer.DefaultOptions,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (JsonException)
+        {
+            File.Delete(_storagePath);
+            return null;
+        }
+    }
+
+    private static string BuildRestoredSummary(ActiveSessionSnapshot snapshot, DateTimeOffset savedAtUtc)
+    {
+        var sourceSummary = snapshot.Source == SessionActivationSource.Broker
+            ? "Resume it to reconnect and replay any missing transcript messages."
+            : "Resume it to keep reading the native transcript from this device.";
+        var savedAtLocal = savedAtUtc.ToLocalTime().ToString("g");
+
+        return $"Recovered '{snapshot.Project?.DisplayName ?? "session"}' from this device (saved {savedAtLocal}). {sourceSummary}";
+    }
+}

--- a/src/SquadScout.App/ViewModels/ActiveSessionViewModel.cs
+++ b/src/SquadScout.App/ViewModels/ActiveSessionViewModel.cs
@@ -1,6 +1,8 @@
-﻿using SquadScout.App.Configuration;
+using System.Text.Json;
+using SquadScout.App.Configuration;
 using SquadScout.App.Navigation;
 using SquadScout.App.Services;
+using SquadScout.Contracts.Messages;
 using SquadScout.Contracts.Sessions;
 
 namespace SquadScout.App.ViewModels;
@@ -11,6 +13,7 @@ public sealed class ActiveSessionViewModel : ViewModelBase
     private readonly IAuthenticationService _authenticationService;
     private readonly IMessageConnectionService _messageConnectionService;
     private readonly IAppNavigator _navigator;
+    private readonly ISessionResumeService _sessionResumeService;
     private readonly ISessionLifecycleService _sessionLifecycleService;
     private readonly SessionTranscriptController _transcriptController;
 
@@ -32,7 +35,9 @@ public sealed class ActiveSessionViewModel : ViewModelBase
     private string _sourceSummary = "No session source";
     private string _startedAt = "—";
     private IReadOnlyList<TranscriptBannerState> _statusBanners = Array.Empty<TranscriptBannerState>();
+    private bool _suspendPersistence;
     private IReadOnlyList<TranscriptMessageState> _transcriptMessages = Array.Empty<TranscriptMessageState>();
+    private string? _restoredTrafficSessionKey;
 
     private ClientIdentity? _identity;
 
@@ -43,6 +48,7 @@ public sealed class ActiveSessionViewModel : ViewModelBase
         ISessionLifecycleService sessionLifecycleService,
         IAuthenticationService authenticationService,
         IMessageConnectionService messageConnectionService,
+        ISessionResumeService sessionResumeService,
         IAppNavigator navigator)
     {
         EnvironmentSummary = $"{environment.Name} • {brokerApiOptions.BaseUrl}";
@@ -50,6 +56,7 @@ public sealed class ActiveSessionViewModel : ViewModelBase
         _sessionLifecycleService = sessionLifecycleService;
         _authenticationService = authenticationService;
         _messageConnectionService = messageConnectionService;
+        _sessionResumeService = sessionResumeService;
         _navigator = navigator;
         _transcriptController = new SessionTranscriptController();
 
@@ -59,13 +66,20 @@ public sealed class ActiveSessionViewModel : ViewModelBase
         SendMessageCommand = new AsyncCommand(SendMessageAsync, () => CanSendMessage && !IsBusy);
         ReconnectLiveTransportCommand = new AsyncCommand(ReconnectLiveTransportAsync, () => HasActiveSession && !IsBusy);
 
-        _activeSessionState.Changed += (_, snapshot) => ApplySnapshot(snapshot);
+        _activeSessionState.Changed += (_, snapshot) =>
+        {
+            ApplySnapshot(snapshot);
+            QueuePersistCurrentSession();
+        };
         _messageConnectionService.StatusChanged += (_, status) =>
             MainThread.BeginInvokeOnMainThread(() =>
             {
                 MessagingSummary = status.Summary;
                 ApplyTranscriptState(_transcriptController.Sync(_activeSessionState.GetSnapshot(), status));
+                QueuePersistCurrentSession();
             });
+        _messageConnectionService.TrafficObserved += (_, traffic) =>
+            MainThread.BeginInvokeOnMainThread(() => HandleTrafficObserved(traffic));
 
         StatusMessage = "Use the composer below to preview the native transcript workflow.";
         ApplySnapshot(_activeSessionState.GetSnapshot());
@@ -253,17 +267,31 @@ public sealed class ActiveSessionViewModel : ViewModelBase
 
     public async Task InitializeAsync()
     {
-        if (!_initialized)
+        _suspendPersistence = true;
+        try
         {
-            _identity = await _authenticationService.GetCurrentIdentityAsync();
-            AuthenticationSummary = $"{_identity.DisplayName} • {_identity.Mode}";
-            _initialized = true;
+            await _sessionResumeService.RestoreAsync();
+
+            if (!_initialized)
+            {
+                _identity = await _authenticationService.GetCurrentIdentityAsync();
+                AuthenticationSummary = $"{_identity.DisplayName} • {_identity.Mode}";
+                _initialized = true;
+            }
+
+            var snapshot = _activeSessionState.GetSnapshot();
+            ApplySnapshot(snapshot);
+            RestorePersistedTrafficIfNeeded(snapshot);
+            await EnsureRestoredSessionPreparedAsync(snapshot);
+            MessagingSummary = _messageConnectionService.CurrentStatus.Summary;
+            ApplyTranscriptState(_transcriptController.Sync(snapshot, _messageConnectionService.CurrentStatus));
+        }
+        finally
+        {
+            _suspendPersistence = false;
         }
 
-        var snapshot = _activeSessionState.GetSnapshot();
-        ApplySnapshot(snapshot);
-        MessagingSummary = _messageConnectionService.CurrentStatus.Summary;
-        ApplyTranscriptState(_transcriptController.Sync(snapshot, _messageConnectionService.CurrentStatus));
+        QueuePersistCurrentSession();
     }
 
     private void ApplySnapshot(ActiveSessionSnapshot snapshot)
@@ -280,6 +308,7 @@ public sealed class ActiveSessionViewModel : ViewModelBase
             StartedAt = "—";
             SourceSummary = "No session source";
             CanRefreshFromBroker = false;
+            _restoredTrafficSessionKey = null;
             ApplyTranscriptState(_transcriptController.Sync(snapshot, _messageConnectionService.CurrentStatus));
             return;
         }
@@ -311,6 +340,7 @@ public sealed class ActiveSessionViewModel : ViewModelBase
             await _messageConnectionService.ResetAsync();
             MessagingSummary = _messageConnectionService.CurrentStatus.Summary;
             _activeSessionState.Clear(summary);
+            await _sessionResumeService.ClearAsync();
             StatusMessage = summary;
             await _navigator.GoToProjectsAsync();
         }
@@ -347,7 +377,8 @@ public sealed class ActiveSessionViewModel : ViewModelBase
 
         try
         {
-            var status = await _messageConnectionService.ReconnectAsync();
+            var snapshot = _activeSessionState.GetSnapshot();
+            var status = await ReconnectCurrentSessionAsync(snapshot);
             MessagingSummary = status.Summary;
             StatusMessage = status.Summary;
             ErrorMessage = status.State == MessageConnectionState.Faulted
@@ -418,6 +449,220 @@ public sealed class ActiveSessionViewModel : ViewModelBase
         RefreshCommands();
     }
 
+    private async Task<MessageConnectionStatus> ReconnectCurrentSessionAsync(ActiveSessionSnapshot snapshot)
+    {
+        if (!snapshot.HasActiveSession || snapshot.Session is null)
+        {
+            return _messageConnectionService.CurrentStatus;
+        }
+
+        var restoredState = _sessionResumeService.CurrentState;
+        var canResumeFromStore = IsRestoredStateForSnapshot(restoredState, snapshot);
+        var currentStatus = _messageConnectionService.CurrentStatus;
+        if (string.Equals(currentStatus.SessionId, snapshot.Session.SessionId, StringComparison.OrdinalIgnoreCase) &&
+            currentStatus.State is not MessageConnectionState.Disconnected)
+        {
+            return await _messageConnectionService.ReconnectAsync();
+        }
+
+        return await _messageConnectionService.PrepareForSessionAsync(
+            snapshot.Session,
+            canResumeFromStore ? restoredState!.Connection : null);
+    }
+
+    private void HandleTrafficObserved(MessageEnvelopeTraffic traffic)
+    {
+        var snapshot = _activeSessionState.GetSnapshot();
+        if (!snapshot.HasActiveSession || snapshot.Session is null)
+        {
+            return;
+        }
+
+        ApplyTranscriptState(_transcriptController.ObserveTraffic(snapshot, _messageConnectionService.CurrentStatus, traffic));
+
+        if (traffic.Direction == MessageTrafficDirection.Incoming &&
+            traffic.Envelope.MessageType == SessionMessageType.SessionLifecycle)
+        {
+            var payload = traffic.Envelope.Payload.Deserialize<SessionLifecyclePayload>(SessionMessageSerializer.DefaultOptions);
+            if (payload is not null && payload.State != snapshot.Session.State)
+            {
+                var summary = string.IsNullOrWhiteSpace(payload.Reason)
+                    ? $"Session state updated to {payload.State} from the live transcript."
+                    : payload.Reason;
+                _activeSessionState.UpdateSession(snapshot.Session with { State = payload.State }, summary);
+            }
+        }
+
+        QueuePersistCurrentSession();
+    }
+
+    private void RestorePersistedTrafficIfNeeded(ActiveSessionSnapshot snapshot)
+    {
+        if (!snapshot.HasActiveSession || snapshot.Session is null)
+        {
+            _restoredTrafficSessionKey = null;
+            return;
+        }
+
+        var restoredState = _sessionResumeService.CurrentState;
+        if (!IsRestoredStateForSnapshot(restoredState, snapshot))
+        {
+            return;
+        }
+
+        var sessionKey = $"{snapshot.Project!.ProjectId}:{snapshot.Session.SessionId}";
+        if (string.Equals(_restoredTrafficSessionKey, sessionKey, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        ApplyTranscriptState(
+            _transcriptController.RestoreFromTraffic(
+                snapshot,
+                _messageConnectionService.CurrentStatus,
+                restoredState!.RecentTraffic));
+        _restoredTrafficSessionKey = sessionKey;
+    }
+
+    private async Task EnsureRestoredSessionPreparedAsync(ActiveSessionSnapshot snapshot)
+    {
+        if (!snapshot.HasActiveSession || snapshot.Session is null || snapshot.Source != SessionActivationSource.Broker)
+        {
+            return;
+        }
+
+        var restoredState = _sessionResumeService.CurrentState;
+        if (!IsRestoredStateForSnapshot(restoredState, snapshot))
+        {
+            return;
+        }
+
+        var currentStatus = _messageConnectionService.CurrentStatus;
+        if (string.Equals(currentStatus.SessionId, snapshot.Session.SessionId, StringComparison.OrdinalIgnoreCase) &&
+            currentStatus.State is MessageConnectionState.Connected or MessageConnectionState.Connecting or MessageConnectionState.Reconnecting)
+        {
+            return;
+        }
+
+        try
+        {
+            var refreshedSession = await _sessionLifecycleService.GetAsync(snapshot.Session.SessionId);
+            if (refreshedSession is null)
+            {
+                await HandleMissingRestoredSessionAsync();
+                return;
+            }
+
+            if (refreshedSession.State != snapshot.Session.State)
+            {
+                _activeSessionState.UpdateSession(refreshedSession, snapshot.Summary);
+            }
+
+            var status = await _messageConnectionService.PrepareForSessionAsync(refreshedSession, restoredState!.Connection);
+            MessagingSummary = status.Summary;
+            StatusMessage = status.Summary;
+            ErrorMessage = status.State == MessageConnectionState.Faulted
+                ? status.FailureReason ?? status.Summary
+                : string.Empty;
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+            StatusMessage = "Saved session restored locally. Retry reconnect when the broker is reachable again.";
+        }
+    }
+
+    private async Task HandleMissingRestoredSessionAsync()
+    {
+        await _messageConnectionService.ResetAsync();
+        await _sessionResumeService.ClearAsync();
+        _activeSessionState.Clear("The saved session is no longer available. Start a new session to continue.");
+        StatusMessage = "The saved session is no longer available.";
+        await _navigator.GoToProjectsAsync();
+    }
+
+    private void QueuePersistCurrentSession()
+    {
+        if (_suspendPersistence)
+        {
+            return;
+        }
+
+        _ = PersistCurrentSessionAsync();
+    }
+
+    private async Task PersistCurrentSessionAsync()
+    {
+        try
+        {
+            var snapshot = _activeSessionState.GetSnapshot();
+            if (!snapshot.HasActiveSession)
+            {
+                await _sessionResumeService.ClearAsync();
+                return;
+            }
+
+            await _sessionResumeService.SaveAsync(new ActiveSessionResumeState
+            {
+                Snapshot = snapshot,
+                Connection = new MessageConnectionResumeState
+                {
+                    Generation = _messageConnectionService.CurrentStatus.Generation,
+                    AcknowledgedSequence = _messageConnectionService.CurrentStatus.AcknowledgedSequence
+                },
+                RecentTraffic = BuildPersistedTraffic(snapshot)
+            });
+        }
+        catch
+        {
+        }
+    }
+
+    private static bool IsRestoredStateForSnapshot(ActiveSessionResumeState? restoredState, ActiveSessionSnapshot snapshot) =>
+        restoredState?.Snapshot.Project is not null &&
+        restoredState.Snapshot.Session is not null &&
+        snapshot.Project is not null &&
+        snapshot.Session is not null &&
+        string.Equals(restoredState.Snapshot.Project.ProjectId, snapshot.Project.ProjectId, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(restoredState.Snapshot.Session.SessionId, snapshot.Session.SessionId, StringComparison.OrdinalIgnoreCase);
+
+    private IReadOnlyList<MessageEnvelopeTraffic> BuildPersistedTraffic(ActiveSessionSnapshot snapshot)
+    {
+        var restoredState = _sessionResumeService.CurrentState;
+        var baseline = IsRestoredStateForSnapshot(restoredState, snapshot)
+            ? restoredState!.RecentTraffic
+            : Array.Empty<MessageEnvelopeTraffic>();
+
+        return baseline
+            .Concat(_messageConnectionService.RecentTraffic)
+            .GroupBy(CreateTrafficPersistenceKey, StringComparer.Ordinal)
+            .Select(group => group.Last())
+            .TakeLast(Math.Max(1, baseline.Count + _messageConnectionService.RecentTraffic.Count))
+            .ToArray();
+    }
+
+    private static string CreateTrafficPersistenceKey(MessageEnvelopeTraffic traffic)
+    {
+        if (!string.IsNullOrWhiteSpace(traffic.Envelope.MessageId))
+        {
+            return $"{traffic.Direction}:{traffic.Envelope.MessageType}:{traffic.Envelope.MessageId}";
+        }
+
+        if (traffic.Envelope.Direction == MessageDirection.BrokerToClient &&
+            traffic.Envelope.Sequence is long sequence)
+        {
+            return $"{traffic.Direction}:{traffic.Envelope.MessageType}:{traffic.Envelope.Generation}:{sequence}";
+        }
+
+        if (traffic.Envelope.Direction == MessageDirection.ClientToBroker &&
+            traffic.Envelope.ClientSequence is long clientSequence)
+        {
+            return $"{traffic.Direction}:{traffic.Envelope.MessageType}:{clientSequence}";
+        }
+
+        return $"{traffic.Direction}:{traffic.Envelope.MessageType}:{traffic.ObservedAtUtc:O}";
+    }
+
     private void NotifySessionChromeChanged()
     {
         OnPropertyChanged(nameof(NavigationHint));
@@ -428,16 +673,38 @@ public sealed class ActiveSessionViewModel : ViewModelBase
     {
         _identity ??= await _authenticationService.GetCurrentIdentityAsync();
 
+        var snapshot = _activeSessionState.GetSnapshot();
+        var connectionStatus = _messageConnectionService.CurrentStatus;
+        var usesLiveTransport = snapshot.Source == SessionActivationSource.Broker && connectionStatus.SupportsLiveSessionStream;
+
         var result = _transcriptController.SendDraft(
-            _activeSessionState.GetSnapshot(),
-            _messageConnectionService.CurrentStatus,
+            snapshot,
+            connectionStatus,
             _identity.DisplayName,
-            ComposerText);
+            ComposerText,
+            appendDraftMessage: !usesLiveTransport);
 
         ApplyTranscriptState(result.ViewState);
         if (!result.Success)
         {
             ErrorMessage = result.ErrorMessage;
+            return;
+        }
+
+        if (usesLiveTransport)
+        {
+            try
+            {
+                await _messageConnectionService.SendInputAsync(ComposerText.Trim());
+                ErrorMessage = string.Empty;
+                ComposerText = string.Empty;
+                StatusMessage = result.StatusMessage;
+            }
+            catch (Exception ex)
+            {
+                ErrorMessage = ex.Message;
+            }
+
             return;
         }
 

--- a/src/SquadScout.App/ViewModels/ProjectSelectionViewModel.cs
+++ b/src/SquadScout.App/ViewModels/ProjectSelectionViewModel.cs
@@ -15,6 +15,7 @@ public sealed class ProjectSelectionViewModel : ViewModelBase
     private readonly IMessageConnectionService _messageConnectionService;
     private readonly IAppNavigator _navigator;
     private readonly IProjectCatalogService _projectCatalogService;
+    private readonly ISessionResumeService _sessionResumeService;
     private readonly ISessionLifecycleService _sessionLifecycleService;
 
     private ActiveSessionSnapshot _activeSessionSnapshot = ActiveSessionSnapshot.Empty;
@@ -35,6 +36,7 @@ public sealed class ProjectSelectionViewModel : ViewModelBase
         ISessionLifecycleService sessionLifecycleService,
         IAuthenticationService authenticationService,
         IMessageConnectionService messageConnectionService,
+        ISessionResumeService sessionResumeService,
         IActiveSessionState activeSessionState,
         IAppNavigator navigator)
     {
@@ -45,6 +47,7 @@ public sealed class ProjectSelectionViewModel : ViewModelBase
         _sessionLifecycleService = sessionLifecycleService;
         _authenticationService = authenticationService;
         _messageConnectionService = messageConnectionService;
+        _sessionResumeService = sessionResumeService;
         _activeSessionState = activeSessionState;
         _navigator = navigator;
 
@@ -235,6 +238,8 @@ public sealed class ProjectSelectionViewModel : ViewModelBase
 
     public async Task InitializeAsync()
     {
+        await _sessionResumeService.RestoreAsync();
+
         if (_initialized)
         {
             ApplyActiveSession(_activeSessionState.GetSnapshot());
@@ -408,6 +413,16 @@ public sealed class ProjectSelectionViewModel : ViewModelBase
             _activeSessionState.SetActiveSession(SelectedProject, launchResult.Session, launchResult.Source, launchResult.Summary);
 
             var connectionStatus = await _messageConnectionService.PrepareForSessionAsync(launchResult.Session);
+            await _sessionResumeService.SaveAsync(new ActiveSessionResumeState
+            {
+                Snapshot = _activeSessionState.GetSnapshot(),
+                Connection = new MessageConnectionResumeState
+                {
+                    Generation = connectionStatus.Generation,
+                    AcknowledgedSequence = connectionStatus.AcknowledgedSequence
+                },
+                RecentTraffic = _messageConnectionService.RecentTraffic.ToArray()
+            });
             StatusMessage = $"{launchResult.Summary} {connectionStatus.Summary}";
             NotifyProjectPresentationChanged();
 

--- a/src/SquadScout.App/ViewModels/SessionTranscriptController.cs
+++ b/src/SquadScout.App/ViewModels/SessionTranscriptController.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using SquadScout.App.Services;
+using SquadScout.Contracts.Messages;
 using SquadScout.Contracts.Sessions;
 
 namespace SquadScout.App.ViewModels;
@@ -7,6 +9,7 @@ public sealed class SessionTranscriptController
 {
     private static readonly TimeSpan GroupWindow = TimeSpan.FromMinutes(5);
 
+    private readonly HashSet<string> _appliedTrafficKeys = new(StringComparer.Ordinal);
     private readonly List<TranscriptMessageState> _messages = [];
     private readonly Func<DateTimeOffset> _utcNow;
 
@@ -22,7 +25,8 @@ public sealed class SessionTranscriptController
         ActiveSessionSnapshot snapshot,
         MessageConnectionStatus connectionStatus,
         string authorDisplayName,
-        string draft)
+        string draft,
+        bool appendDraftMessage = true)
     {
         if (!snapshot.HasActiveSession || snapshot.Session is null)
         {
@@ -63,19 +67,21 @@ public sealed class SessionTranscriptController
         }
 
         EnsureSession(snapshot);
-
-        AppendMessage(
-            TranscriptMessageSpeaker.LocalUser,
-            string.IsNullOrWhiteSpace(authorDisplayName) ? "You" : authorDisplayName.Trim(),
-            normalizedDraft,
-            isError: false,
-            isSystem: false);
+        if (appendDraftMessage)
+        {
+            AppendMessage(
+                TranscriptMessageSpeaker.LocalUser,
+                string.IsNullOrWhiteSpace(authorDisplayName) ? "You" : authorDisplayName.Trim(),
+                normalizedDraft,
+                isError: false,
+                isSystem: false);
+        }
 
         var statusMessage = connectionStatus.SupportsLiveSessionStream && connectionStatus.State == MessageConnectionState.Connected
             ? "Sent the message to the live session stream."
             : snapshot.Source == SessionActivationSource.DevelopmentFallback
                 ? "Captured the message in the offline transcript preview."
-                : "Captured the message in the native transcript preview while live streaming lands in #11.";
+                : "Captured the message in the native transcript preview while live delivery is unavailable.";
 
         return new TranscriptSendResult(
             Success: true,
@@ -84,24 +90,55 @@ public sealed class SessionTranscriptController
             ViewState: BuildViewState(snapshot, connectionStatus));
     }
 
+    public SessionTranscriptViewState RestoreFromTraffic(
+        ActiveSessionSnapshot snapshot,
+        MessageConnectionStatus connectionStatus,
+        IReadOnlyList<MessageEnvelopeTraffic> trafficHistory)
+    {
+        if (!snapshot.HasActiveSession || snapshot.Session is null)
+        {
+            ResetSessionState();
+            return BuildViewState(snapshot, connectionStatus);
+        }
+
+        EnsureSession(snapshot, clearMessages: true);
+        foreach (var traffic in trafficHistory)
+        {
+            ApplyTraffic(snapshot, traffic);
+        }
+
+        return BuildViewState(snapshot, connectionStatus);
+    }
+
+    public SessionTranscriptViewState ObserveTraffic(
+        ActiveSessionSnapshot snapshot,
+        MessageConnectionStatus connectionStatus,
+        MessageEnvelopeTraffic traffic)
+    {
+        if (!snapshot.HasActiveSession || snapshot.Session is null)
+        {
+            return BuildViewState(snapshot, connectionStatus);
+        }
+
+        EnsureSession(snapshot);
+        ApplyTraffic(snapshot, traffic);
+        return BuildViewState(snapshot, connectionStatus);
+    }
+
     public SessionTranscriptViewState Sync(
         ActiveSessionSnapshot snapshot,
         MessageConnectionStatus connectionStatus)
     {
         if (!snapshot.HasActiveSession || snapshot.Session is null)
         {
-            _sessionKey = null;
-            _trackedState = null;
-            _messages.Clear();
+            ResetSessionState();
             return BuildViewState(snapshot, connectionStatus);
         }
 
         var nextSessionKey = CreateSessionKey(snapshot);
         if (!string.Equals(_sessionKey, nextSessionKey, StringComparison.Ordinal))
         {
-            _messages.Clear();
-            _sessionKey = nextSessionKey;
-            _trackedState = snapshot.Session.State;
+            EnsureSession(snapshot, clearMessages: true);
             return BuildViewState(snapshot, connectionStatus);
         }
 
@@ -114,13 +151,172 @@ public sealed class SessionTranscriptController
         return BuildViewState(snapshot, connectionStatus);
     }
 
-    private void AppendLifecycleMessage(SessionState sessionState)
+    private void ApplyTraffic(ActiveSessionSnapshot snapshot, MessageEnvelopeTraffic traffic)
+    {
+        if (!MatchesSession(snapshot, traffic.Envelope))
+        {
+            return;
+        }
+
+        var trafficKey = CreateTrafficKey(traffic);
+        if (!string.IsNullOrWhiteSpace(trafficKey) && !_appliedTrafficKeys.Add(trafficKey))
+        {
+            return;
+        }
+
+        switch (traffic.Direction, traffic.Envelope.MessageType)
+        {
+            case (MessageTrafficDirection.Outgoing, SessionMessageType.Input):
+                TryAppendOutgoingInput(traffic.Envelope);
+                break;
+
+            case (MessageTrafficDirection.Outgoing, SessionMessageType.ReplayRequest):
+                TryAppendReplayRequest(traffic.Envelope);
+                break;
+
+            case (MessageTrafficDirection.Incoming, SessionMessageType.Output):
+                TryAppendIncomingOutput(traffic.Envelope);
+                break;
+
+            case (MessageTrafficDirection.Incoming, SessionMessageType.SessionLifecycle):
+                TryAppendLifecycleEnvelope(traffic.Envelope);
+                break;
+
+            case (MessageTrafficDirection.Incoming, SessionMessageType.ReplayResponse):
+                TryAppendReplayResponse(traffic.Envelope);
+                break;
+        }
+    }
+
+    private void TryAppendOutgoingInput(MessageEnvelope<JsonElement> envelope)
+    {
+        var payload = envelope.Payload.Deserialize<InputChunkPayload>(SessionMessageSerializer.DefaultOptions);
+        if (payload is null || string.IsNullOrWhiteSpace(payload.Content))
+        {
+            return;
+        }
+
+        AppendMessage(
+            TranscriptMessageSpeaker.LocalUser,
+            "You",
+            payload.Content.Trim(),
+            isError: false,
+            isSystem: false);
+    }
+
+    private void TryAppendIncomingOutput(MessageEnvelope<JsonElement> envelope)
+    {
+        var payload = envelope.Payload.Deserialize<OutputChunkPayload>(SessionMessageSerializer.DefaultOptions);
+        if (payload is null || string.IsNullOrWhiteSpace(payload.Content))
+        {
+            return;
+        }
+
+        AppendMessage(
+            TranscriptMessageSpeaker.RemoteAgent,
+            "SquadScout",
+            payload.Content,
+            payload.IsError,
+            isSystem: false);
+    }
+
+    private void TryAppendLifecycleEnvelope(MessageEnvelope<JsonElement> envelope)
+    {
+        var payload = envelope.Payload.Deserialize<SessionLifecyclePayload>(SessionMessageSerializer.DefaultOptions);
+        if (payload is null)
+        {
+            return;
+        }
+
+        AppendLifecycleMessage(payload.State, payload.Reason);
+        _trackedState = payload.State;
+    }
+
+    private void TryAppendReplayRequest(MessageEnvelope<JsonElement> envelope)
+    {
+        var payload = envelope.Payload.Deserialize<ReplayRequestPayload>(SessionMessageSerializer.DefaultOptions);
+        if (payload is null)
+        {
+            return;
+        }
+
+        var reasonText = payload.Reason switch
+        {
+            ReplayRequestReason.ClientRecovery => "Resuming this session from the device cache.",
+            ReplayRequestReason.ReconnectResume => "Reconnected to the broker.",
+            _ => "Transcript continuity was interrupted."
+        };
+
+        AppendMessage(
+            TranscriptMessageSpeaker.System,
+            "SquadScout",
+            $"{reasonText} Recovering transcript messages from sequence {payload.FromSequenceInclusive}.",
+            isError: false,
+            isSystem: true);
+    }
+
+    private void TryAppendReplayResponse(MessageEnvelope<JsonElement> envelope)
+    {
+        var payload = envelope.Payload.Deserialize<ReplayResponsePayload>(SessionMessageSerializer.DefaultOptions);
+        if (payload is null)
+        {
+            return;
+        }
+
+        if (payload.GapDetected)
+        {
+            var windowText = payload.AvailableFromSequence is long availableFrom && payload.AvailableToSequence is long availableTo
+                ? $" Available replay window: {availableFrom}-{availableTo}."
+                : string.Empty;
+
+            AppendMessage(
+                TranscriptMessageSpeaker.System,
+                "SquadScout",
+                $"Replay could not fully recover the transcript. Some context is no longer available from the broker.{windowText}",
+                isError: true,
+                isSystem: true);
+            return;
+        }
+
+        if (payload.HasMore)
+        {
+            AppendMessage(
+                TranscriptMessageSpeaker.System,
+                "SquadScout",
+                $"Recovered {payload.Messages.Count} transcript message(s). Loading more from the broker…",
+                isError: false,
+                isSystem: true);
+            return;
+        }
+
+        if (payload.Messages.Count > 0)
+        {
+            AppendMessage(
+                TranscriptMessageSpeaker.System,
+                "SquadScout",
+                $"Recovered {payload.Messages.Count} transcript message(s). Live continuity is restored.",
+                isError: false,
+                isSystem: true);
+            return;
+        }
+
+        AppendMessage(
+            TranscriptMessageSpeaker.System,
+            "SquadScout",
+            "The session is current. No transcript replay was needed.",
+            isError: false,
+            isSystem: true);
+    }
+
+    private void AppendLifecycleMessage(SessionState sessionState, string? reason = null)
     {
         var text = sessionState switch
         {
             SessionState.Pending => "The broker created the session. New transcript activity will appear here when it starts flowing.",
             SessionState.Running => "The session is running. Incoming replies will stack here in chat form.",
-            SessionState.Stopped => "The session has ended. Review the transcript here, but sending is disabled.",
+            SessionState.Stopped when string.IsNullOrWhiteSpace(reason) =>
+                "The session has ended. Review the transcript here, but sending is disabled.",
+            SessionState.Stopped => $"The session has ended. {reason}".Trim(),
             _ => "The session state changed."
         };
 
@@ -214,8 +410,17 @@ public sealed class SessionTranscriptController
         {
             banners.Add(new TranscriptBannerState(
                 "Transcript preview",
-                "This screen is wired for native chat UX now; PubSub-backed live delivery lands in #11.",
+                "This screen keeps the native chat UX even when live delivery is unavailable.",
                 TranscriptBannerSeverity.Info));
+        }
+        else if (connectionStatus.IsReplayPending)
+        {
+            banners.Add(new TranscriptBannerState(
+                connectionStatus.ReplayReason == ReplayRequestReason.ClientRecovery
+                    ? "Resuming saved session"
+                    : "Recovering transcript",
+                connectionStatus.Summary,
+                TranscriptBannerSeverity.Warning));
         }
         else if (connectionStatus.State != MessageConnectionState.Connected)
         {
@@ -230,6 +435,15 @@ public sealed class SessionTranscriptController
                 connectionStatus.State == MessageConnectionState.Faulted
                     ? TranscriptBannerSeverity.Error
                     : TranscriptBannerSeverity.Warning));
+        }
+
+        if (connectionStatus.ReplayAvailableFromSequence is long availableFrom &&
+            connectionStatus.ReplayAvailableToSequence is long availableTo)
+        {
+            banners.Add(new TranscriptBannerState(
+                "Replay gap detected",
+                $"The broker can only replay messages {availableFrom}-{availableTo}. Earlier context must be treated as missing.",
+                TranscriptBannerSeverity.Error));
         }
 
         if (snapshot.Source == SessionActivationSource.DevelopmentFallback)
@@ -282,12 +496,17 @@ public sealed class SessionTranscriptController
 
         if (!connectionStatus.SupportsLiveSessionStream)
         {
-            return "Send a message to preview the chat timeline while live PubSub delivery lands in #11.";
+            return "Send a message to preview the chat timeline while live delivery is unavailable.";
         }
 
         if (snapshot.Session?.State == SessionState.Pending)
         {
             return "The broker is still starting this session. Messaging unlocks once the live session is running.";
+        }
+
+        if (connectionStatus.IsReplayPending)
+        {
+            return "Replaying recent messages from the broker before trusting transcript continuity.";
         }
 
         if (connectionStatus.State != MessageConnectionState.Connected)
@@ -349,6 +568,11 @@ public sealed class SessionTranscriptController
             return null;
         }
 
+        if (connectionStatus.IsReplayPending)
+        {
+            return "Live messaging is recovering transcript continuity. Wait for replay to finish before sending.";
+        }
+
         if (snapshot.Session.State == SessionState.Pending)
         {
             return "Wait for the broker to start the session before sending messages.";
@@ -366,16 +590,61 @@ public sealed class SessionTranscriptController
         };
     }
 
-    private void EnsureSession(ActiveSessionSnapshot snapshot)
+    private void EnsureSession(ActiveSessionSnapshot snapshot, bool clearMessages = false)
     {
         var nextSessionKey = CreateSessionKey(snapshot);
         if (string.Equals(_sessionKey, nextSessionKey, StringComparison.Ordinal))
         {
+            if (clearMessages)
+            {
+                _messages.Clear();
+                _appliedTrafficKeys.Clear();
+                _trackedState = snapshot.Session!.State;
+            }
+
             return;
         }
 
         _messages.Clear();
+        _appliedTrafficKeys.Clear();
         _sessionKey = nextSessionKey;
         _trackedState = snapshot.Session!.State;
+    }
+
+    private void ResetSessionState()
+    {
+        _sessionKey = null;
+        _trackedState = null;
+        _messages.Clear();
+        _appliedTrafficKeys.Clear();
+    }
+
+    private static bool MatchesSession(ActiveSessionSnapshot snapshot, MessageEnvelope<JsonElement> envelope) =>
+        snapshot.Project is not null &&
+        snapshot.Session is not null &&
+        string.Equals(snapshot.Project.ProjectId, envelope.ProjectId, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(snapshot.Session.SessionId, envelope.SessionId, StringComparison.OrdinalIgnoreCase);
+
+    private static string? CreateTrafficKey(MessageEnvelopeTraffic traffic)
+    {
+        var envelope = traffic.Envelope;
+        if (!string.IsNullOrWhiteSpace(envelope.MessageId))
+        {
+            return $"{traffic.Direction}:{envelope.MessageType}:{envelope.MessageId}";
+        }
+
+        if (envelope.Direction == MessageDirection.BrokerToClient &&
+            envelope.Sequence is long sequence)
+        {
+            return $"{traffic.Direction}:{envelope.MessageType}:{envelope.Generation}:{sequence}";
+        }
+
+        if (envelope.Direction == MessageDirection.ClientToBroker &&
+            envelope.ClientSequence is long clientSequence)
+        {
+            return $"{traffic.Direction}:{envelope.MessageType}:{clientSequence}";
+        }
+
+        return null;
     }
 }

--- a/tests/SquadScout.App.Tests/ActiveSessionViewModelTests.cs
+++ b/tests/SquadScout.App.Tests/ActiveSessionViewModelTests.cs
@@ -1,6 +1,8 @@
+using System.Text.Json;
 using SquadScout.App.Configuration;
 using SquadScout.App.Services;
 using SquadScout.App.ViewModels;
+using SquadScout.Contracts.Messages;
 using SquadScout.Contracts.Projects;
 using SquadScout.Contracts.Sessions;
 
@@ -223,10 +225,128 @@ public sealed class ActiveSessionViewModelTests
         Assert.Equal("Draft a message in the native transcript preview.", viewModel.ComposerPlaceholder);
     }
 
+    [Fact]
+    public async Task InitializeAsync_RestoredBrokerSession_RehydratesTranscriptAndRequestsClientRecovery()
+    {
+        var activeState = new ActiveSessionState();
+        var project = CreateProject("squadscout", "SquadScout");
+        var restoredSession = CreateSession("squadscout", "session-restore", SessionState.Running);
+        var resumeService = new RecordingSessionResumeService();
+        resumeService.SetCurrentState(new ActiveSessionResumeState
+        {
+            Snapshot = new ActiveSessionSnapshot(
+                project,
+                restoredSession,
+                SessionActivationSource.Broker,
+                "Recovered session."),
+            Connection = new MessageConnectionResumeState
+            {
+                Generation = 3,
+                AcknowledgedSequence = 7
+            },
+            RecentTraffic =
+            [
+                CreateTraffic(CreateInputEnvelope(project.ProjectId, restoredSession.SessionId, 3, 1, "resume me")),
+                CreateTraffic(CreateOutputEnvelope(project.ProjectId, restoredSession.SessionId, 3, 7, "restored reply"))
+            ]
+        });
+        resumeService.OnRestoreAsync = () =>
+        {
+            activeState.SetActiveSession(
+                project,
+                restoredSession,
+                SessionActivationSource.Broker,
+                "Recovered from device storage.");
+            return Task.CompletedTask;
+        };
+
+        var lifecycle = new RecordingSessionLifecycleService
+        {
+            OnGetAsync = _ => Task.FromResult<SessionDescriptor?>(restoredSession)
+        };
+
+        MessageConnectionResumeState? observedResume = null;
+        var messageConnection = new RecordingMessageConnectionService(new MessageConnectionStatus
+        {
+            State = MessageConnectionState.Disconnected,
+            Summary = "Messaging disconnected.",
+            SupportsLiveSessionStream = true
+        });
+        messageConnection.OnPrepareForSessionAsync = (session, resumeState) =>
+        {
+            observedResume = resumeState;
+            return Task.FromResult(new MessageConnectionStatus
+            {
+                State = MessageConnectionState.Connected,
+                Summary = "Resumed live messaging.",
+                SupportsLiveSessionStream = true,
+                SessionId = session.SessionId,
+                Generation = resumeState?.Generation ?? SessionEnvelopeContract.InitialGeneration,
+                AcknowledgedSequence = resumeState?.AcknowledgedSequence
+            });
+        };
+
+        var viewModel = CreateViewModel(
+            activeSessionState: activeState,
+            connectionService: messageConnection,
+            sessionResumeService: resumeService,
+            sessionLifecycle: lifecycle);
+
+        await viewModel.InitializeAsync();
+
+        Assert.True(viewModel.HasActiveSession);
+        Assert.Equal(1, messageConnection.PrepareForSessionCallCount);
+        Assert.NotNull(observedResume);
+        Assert.Equal(3, observedResume!.Generation);
+        Assert.Equal(7, observedResume.AcknowledgedSequence);
+        Assert.Contains(viewModel.TranscriptMessages, message => message.Text.Contains("resume me", StringComparison.Ordinal));
+        Assert.Contains(viewModel.TranscriptMessages, message => message.Text.Contains("restored reply", StringComparison.Ordinal));
+        Assert.Equal("Resumed live messaging.", viewModel.StatusMessage);
+    }
+
+    [Fact]
+    public async Task TrafficObserved_WhenReplayRequestStarts_ShowsResumeRecoveryMessageAndDisablesComposer()
+    {
+        var activeState = new ActiveSessionState();
+        activeState.SetActiveSession(
+            CreateProject("squadscout", "SquadScout"),
+            CreateSession("squadscout", "session-15", SessionState.Running),
+            SessionActivationSource.Broker,
+            "Broker-backed session.");
+
+        var messageConnection = new RecordingMessageConnectionService(new MessageConnectionStatus
+        {
+            State = MessageConnectionState.Connected,
+            Summary = "Connected to session stream.",
+            SupportsLiveSessionStream = true,
+            SessionId = "session-15"
+        });
+
+        var viewModel = CreateViewModel(activeSessionState: activeState, connectionService: messageConnection);
+        await viewModel.InitializeAsync();
+
+        messageConnection.PublishStatus(messageConnection.CurrentStatus with
+        {
+            IsReplayPending = true,
+            ReplayReason = ReplayRequestReason.ClientRecovery,
+            ReplayFromSequenceInclusive = 4,
+            Summary = "Resuming session 'session-15' from this device. Recovering transcript continuity from sequence 4."
+        });
+        messageConnection.PublishTraffic(CreateTraffic(CreateReplayRequestEnvelope("squadscout", "session-15", ReplayRequestReason.ClientRecovery, 4)));
+
+        Assert.False(viewModel.CanSendMessage);
+        Assert.Equal(
+            "Live messaging is recovering transcript continuity. Wait for replay to finish before sending.",
+            viewModel.ComposerPlaceholder);
+        Assert.Contains(viewModel.TranscriptMessages, message => message.Text.Contains("Recovering transcript messages from sequence 4", StringComparison.Ordinal));
+        Assert.Contains(viewModel.StatusBanners, banner => banner.Title == "Resuming saved session");
+    }
+
     private static ActiveSessionViewModel CreateViewModel(
         ActiveSessionState? activeSessionState = null,
         StubAuthenticationService? authenticationService = null,
         RecordingMessageConnectionService? connectionService = null,
+        ISessionResumeService? sessionResumeService = null,
         RecordingNavigator? navigator = null,
         RecordingSessionLifecycleService? sessionLifecycle = null)
     {
@@ -237,6 +357,7 @@ public sealed class ActiveSessionViewModelTests
             sessionLifecycle ?? new RecordingSessionLifecycleService(),
             authenticationService ?? new StubAuthenticationService(new ClientIdentity("ryan", "Ryan Graham", "BrokerNegotiated")),
             connectionService ?? new RecordingMessageConnectionService(),
+            sessionResumeService ?? new RecordingSessionResumeService(),
             navigator ?? new RecordingNavigator());
     }
 
@@ -255,5 +376,102 @@ public sealed class ActiveSessionViewModelTests
             ProjectId = projectId,
             State = state,
             CreatedAtUtc = new DateTimeOffset(2026, 03, 25, 11, 30, 00, TimeSpan.Zero)
+        };
+
+    private static MessageEnvelopeTraffic CreateTraffic<TPayload>(MessageEnvelope<TPayload> envelope) =>
+        new()
+        {
+            Direction = envelope.Direction == MessageDirection.BrokerToClient
+                ? MessageTrafficDirection.Incoming
+                : MessageTrafficDirection.Outgoing,
+            Envelope = ToJsonEnvelope(envelope),
+            Summary = envelope.MessageType.ToString()
+        };
+
+    private static MessageEnvelope<InputChunkPayload> CreateInputEnvelope(
+        string projectId,
+        string sessionId,
+        long generation,
+        long clientSequence,
+        string content) =>
+        new()
+        {
+            ProjectId = projectId,
+            SessionId = sessionId,
+            Generation = generation,
+            MessageType = SessionMessageType.Input,
+            Direction = MessageDirection.ClientToBroker,
+            ClientSequence = clientSequence,
+            TimestampUtc = DateTimeOffset.UtcNow,
+            MessageId = $"client-{clientSequence}",
+            CorrelationId = $"mobile-session:{sessionId}",
+            Payload = new InputChunkPayload
+            {
+                Content = content
+            }
+        };
+
+    private static MessageEnvelope<OutputChunkPayload> CreateOutputEnvelope(
+        string projectId,
+        string sessionId,
+        long generation,
+        long sequence,
+        string content) =>
+        new()
+        {
+            ProjectId = projectId,
+            SessionId = sessionId,
+            Generation = generation,
+            MessageType = SessionMessageType.Output,
+            Direction = MessageDirection.BrokerToClient,
+            Sequence = sequence,
+            TimestampUtc = DateTimeOffset.UtcNow,
+            MessageId = $"broker-{sequence}",
+            CorrelationId = $"broker-session:{sessionId}",
+            Payload = new OutputChunkPayload
+            {
+                Content = content
+            }
+        };
+
+    private static MessageEnvelope<ReplayRequestPayload> CreateReplayRequestEnvelope(
+        string projectId,
+        string sessionId,
+        ReplayRequestReason reason,
+        long fromSequenceInclusive) =>
+        new()
+        {
+            ProjectId = projectId,
+            SessionId = sessionId,
+            Generation = SessionEnvelopeContract.InitialGeneration,
+            MessageType = SessionMessageType.ReplayRequest,
+            Direction = MessageDirection.ClientToBroker,
+            TimestampUtc = DateTimeOffset.UtcNow,
+            MessageId = $"replay-{fromSequenceInclusive}",
+            CorrelationId = $"mobile-session:{sessionId}",
+            Payload = new ReplayRequestPayload
+            {
+                FromSequenceInclusive = fromSequenceInclusive,
+                Reason = reason
+            }
+        };
+
+    private static MessageEnvelope<JsonElement> ToJsonEnvelope<TPayload>(MessageEnvelope<TPayload> envelope) =>
+        new()
+        {
+            ContractVersion = envelope.ContractVersion,
+            ProjectId = envelope.ProjectId,
+            SessionId = envelope.SessionId,
+            Generation = envelope.Generation,
+            MessageType = envelope.MessageType,
+            Direction = envelope.Direction,
+            Sequence = envelope.Sequence,
+            ClientSequence = envelope.ClientSequence,
+            AcknowledgedSequence = envelope.AcknowledgedSequence,
+            TimestampUtc = envelope.TimestampUtc,
+            MessageId = envelope.MessageId,
+            CorrelationId = envelope.CorrelationId,
+            CausationId = envelope.CausationId,
+            Payload = JsonSerializer.SerializeToElement(envelope.Payload, SessionMessageSerializer.DefaultOptions)
         };
 }

--- a/tests/SquadScout.App.Tests/ProjectSelectionViewModelTests.cs
+++ b/tests/SquadScout.App.Tests/ProjectSelectionViewModelTests.cs
@@ -116,6 +116,41 @@ public sealed class ProjectSelectionViewModelTests
     }
 
     [Fact]
+    public async Task InitializeAsync_RestoresSavedSessionBeforeShowingResumeCard()
+    {
+        var project = CreateProject("squadscout", "SquadScout");
+        var activeState = new ActiveSessionState();
+        var resumeService = new RecordingSessionResumeService
+        {
+            OnRestoreAsync = () =>
+            {
+                activeState.SetActiveSession(
+                    project,
+                    CreateSession(project.ProjectId, "session-restored", SessionState.Running),
+                    SessionActivationSource.Broker,
+                    "Recovered from this device.");
+                return Task.CompletedTask;
+            }
+        };
+
+        var projectCatalog = new ScriptedProjectCatalogService();
+        projectCatalog.EnqueueResult(CreateCatalogSnapshot(project));
+
+        var viewModel = CreateViewModel(
+            activeSessionState: activeState,
+            sessionResumeService: resumeService,
+            projectCatalog: projectCatalog);
+
+        await viewModel.InitializeAsync();
+
+        Assert.Equal(1, resumeService.RestoreCallCount);
+        Assert.True(viewModel.HasActiveSession);
+        Assert.Equal("Recovered from this device.", viewModel.SessionSummary);
+        Assert.True(viewModel.ResumeActiveSessionCommand.CanExecute(null));
+        Assert.False(viewModel.StartSessionCommand.CanExecute(null));
+    }
+
+    [Fact]
     public async Task StartSessionAsync_NormalizesRequestAndNavigatesToTranscript()
     {
         var project = CreateProject("squadscout", "SquadScout");
@@ -131,7 +166,7 @@ public sealed class ProjectSelectionViewModelTests
         };
 
         var messageConnection = new RecordingMessageConnectionService();
-        messageConnection.OnPrepareForSessionAsync = session => Task.FromResult(new MessageConnectionStatus
+        messageConnection.OnPrepareForSessionAsync = (session, _) => Task.FromResult(new MessageConnectionStatus
         {
             State = MessageConnectionState.Ready,
             Summary = "Messaging composition is ready for the session.",
@@ -140,13 +175,15 @@ public sealed class ProjectSelectionViewModelTests
         });
 
         var activeState = new ActiveSessionState();
+        var resumeService = new RecordingSessionResumeService();
         var navigator = new RecordingNavigator();
         var viewModel = CreateViewModel(
             activeSessionState: activeState,
             navigator: navigator,
             projectCatalog: projectCatalog,
             sessionLifecycle: lifecycle,
-            connectionService: messageConnection);
+            connectionService: messageConnection,
+            sessionResumeService: resumeService);
 
         await viewModel.InitializeAsync();
         viewModel.RequestedBy = "   ";
@@ -166,12 +203,14 @@ public sealed class ProjectSelectionViewModelTests
         Assert.Equal("session-15", snapshot.Session?.SessionId);
         Assert.Contains("Started a broker-backed pending session.", viewModel.StatusMessage, StringComparison.Ordinal);
         Assert.Contains("Messaging composition is ready for the session.", viewModel.StatusMessage, StringComparison.Ordinal);
+        Assert.Equal(1, resumeService.SaveCallCount);
     }
 
     private static ProjectSelectionViewModel CreateViewModel(
         ActiveSessionState? activeSessionState = null,
         StubAuthenticationService? authenticationService = null,
         RecordingMessageConnectionService? connectionService = null,
+        RecordingSessionResumeService? sessionResumeService = null,
         RecordingNavigator? navigator = null,
         ScriptedProjectCatalogService? projectCatalog = null,
         RecordingSessionLifecycleService? sessionLifecycle = null)
@@ -183,6 +222,7 @@ public sealed class ProjectSelectionViewModelTests
             sessionLifecycle ?? new RecordingSessionLifecycleService(),
             authenticationService ?? new StubAuthenticationService(new ClientIdentity("ryan", "Ryan Graham", "BrokerNegotiated")),
             connectionService ?? new RecordingMessageConnectionService(),
+            sessionResumeService ?? new RecordingSessionResumeService(),
             activeSessionState ?? new ActiveSessionState(),
             navigator ?? new RecordingNavigator());
     }

--- a/tests/SquadScout.App.Tests/PubSubConnectionServiceTests.cs
+++ b/tests/SquadScout.App.Tests/PubSubConnectionServiceTests.cs
@@ -446,6 +446,69 @@ public sealed class PubSubConnectionServiceTests
     }
 
     [Fact]
+    public async Task ReplayResponseWithHasMoreAndEmptyPageRequestsAnotherPageBeforeRestoringConnectedStatus()
+    {
+        var session = CreateSession();
+        var socket = new FakeWebPubSubSocket
+        {
+            ConnectFrames =
+            [
+                SystemMessage("connected", connectionId: "conn-empty-page-replay")
+            ],
+            OnSendAsync = command =>
+            {
+                var json = JsonDocument.Parse(command);
+                var ackId = json.RootElement.GetProperty("ackId").GetInt64();
+                return Task.FromResult<string?>(AckMessage(ackId, success: true));
+            }
+        };
+
+        await using var service = CreateService(new RecordingNegotiationClient(CreateNegotiationResponse(session)), socket);
+        await service.PrepareForSessionAsync(session, new MessageConnectionResumeState
+        {
+            Generation = SessionEnvelopeContract.InitialGeneration
+        });
+        await WaitForAsync(() => socket.SentTexts.Count >= 2);
+
+        socket.EnqueueIncoming(GroupMessage(CreateReplayResponseEnvelope(
+            session,
+            hasMore: true,
+            availableFromSequence: 1,
+            availableToSequence: 4,
+            messages: [])));
+        await WaitForAsync(() => socket.SentTexts.Count >= 3);
+
+        using (var secondReplayCommand = JsonDocument.Parse(socket.SentTexts[2]))
+        {
+            var secondReplayRequest = secondReplayCommand.RootElement.GetProperty("data")
+                .Deserialize<MessageEnvelope<ReplayRequestPayload>>(SessionMessageSerializer.DefaultOptions);
+
+            Assert.NotNull(secondReplayRequest);
+            Assert.Equal(ReplayRequestReason.ClientRecovery, secondReplayRequest!.Payload.Reason);
+            Assert.Equal(1, secondReplayRequest.Payload.FromSequenceInclusive);
+            Assert.Equal(4, secondReplayRequest.Payload.ToSequenceInclusive);
+        }
+
+        Assert.True(service.CurrentStatus.IsReplayPending);
+
+        socket.EnqueueIncoming(GroupMessage(CreateReplayResponseEnvelope(
+            session,
+            availableFromSequence: 1,
+            availableToSequence: 4,
+            messages:
+            [
+                ToJsonEnvelope(CreateBrokerEnvelope(session, sequence: 1)),
+                ToJsonEnvelope(CreateBrokerEnvelope(session, sequence: 2)),
+                ToJsonEnvelope(CreateBrokerEnvelope(session, sequence: 3)),
+                ToJsonEnvelope(CreateBrokerEnvelope(session, sequence: 4))
+            ])));
+        await WaitForAsync(() => service.CurrentStatus.State == MessageConnectionState.Connected && !service.CurrentStatus.IsReplayPending);
+
+        Assert.Equal(4, service.CurrentStatus.AcknowledgedSequence);
+        Assert.Contains(service.RecentTraffic, traffic => traffic.Direction == MessageTrafficDirection.Incoming && traffic.Envelope.Sequence == 4);
+    }
+
+    [Fact]
     public async Task PrepareForSessionAsyncSchedulesTokenRefreshBeforeRefreshAtUtc()
     {
         var session = CreateSession();

--- a/tests/SquadScout.App.Tests/PubSubConnectionServiceTests.cs
+++ b/tests/SquadScout.App.Tests/PubSubConnectionServiceTests.cs
@@ -273,6 +273,47 @@ public sealed class PubSubConnectionServiceTests
     }
 
     [Fact]
+    public async Task PrepareForSessionAsync_WithResumeStateRequestsClientRecoveryReplay()
+    {
+        var session = CreateSession();
+        var socket = new FakeWebPubSubSocket
+        {
+            ConnectFrames =
+            [
+                SystemMessage("connected", connectionId: "conn-restore")
+            ],
+            OnSendAsync = command =>
+            {
+                var json = JsonDocument.Parse(command);
+                var ackId = json.RootElement.GetProperty("ackId").GetInt64();
+                return Task.FromResult<string?>(AckMessage(ackId, success: true));
+            }
+        };
+
+        await using var service = CreateService(new RecordingNegotiationClient(CreateNegotiationResponse(session)), socket);
+        var status = await service.PrepareForSessionAsync(session, new MessageConnectionResumeState
+        {
+            Generation = 2,
+            AcknowledgedSequence = 5
+        });
+        await WaitForAsync(() => socket.SentTexts.Count >= 2);
+
+        using var replayCommand = JsonDocument.Parse(socket.SentTexts[1]);
+        var replayRequest = replayCommand.RootElement.GetProperty("data")
+            .Deserialize<MessageEnvelope<ReplayRequestPayload>>(SessionMessageSerializer.DefaultOptions);
+
+        Assert.NotNull(replayRequest);
+        Assert.Equal(MessageConnectionState.Connected, status.State);
+        Assert.True(service.CurrentStatus.IsReplayPending);
+        Assert.Equal(ReplayRequestReason.ClientRecovery, service.CurrentStatus.ReplayReason);
+        Assert.Equal(6, service.CurrentStatus.ReplayFromSequenceInclusive);
+        Assert.Equal(ReplayRequestReason.ClientRecovery, replayRequest!.Payload.Reason);
+        Assert.Equal(2, replayRequest.Generation);
+        Assert.Equal(5, replayRequest.AcknowledgedSequence);
+        Assert.Equal(6, replayRequest.Payload.FromSequenceInclusive);
+    }
+
+    [Fact]
     public async Task DuplicateReplayResponseEnvelopeIsIgnoredOnTheReplayPath()
     {
         var session = CreateSession();
@@ -339,6 +380,69 @@ public sealed class PubSubConnectionServiceTests
             traffic.Direction == MessageTrafficDirection.Incoming &&
             traffic.Envelope.MessageType == SessionMessageType.ReplayResponse &&
             traffic.Envelope.MessageId == "replay-fixed"));
+    }
+
+    [Fact]
+    public async Task ReplayResponseWithHasMoreRequestsAnotherPageBeforeRestoringConnectedStatus()
+    {
+        var session = CreateSession();
+        var socket = new FakeWebPubSubSocket
+        {
+            ConnectFrames =
+            [
+                SystemMessage("connected", connectionId: "conn-paged-replay")
+            ],
+            OnSendAsync = command =>
+            {
+                var json = JsonDocument.Parse(command);
+                var ackId = json.RootElement.GetProperty("ackId").GetInt64();
+                return Task.FromResult<string?>(AckMessage(ackId, success: true));
+            }
+        };
+
+        await using var service = CreateService(new RecordingNegotiationClient(CreateNegotiationResponse(session)), socket);
+        await service.PrepareForSessionAsync(session, new MessageConnectionResumeState
+        {
+            Generation = SessionEnvelopeContract.InitialGeneration
+        });
+        await WaitForAsync(() => socket.SentTexts.Count >= 2);
+
+        socket.EnqueueIncoming(GroupMessage(CreateReplayResponseEnvelope(
+            session,
+            hasMore: true,
+            availableFromSequence: 1,
+            availableToSequence: 4,
+            messages:
+            [
+                ToJsonEnvelope(CreateBrokerEnvelope(session, sequence: 1)),
+                ToJsonEnvelope(CreateBrokerEnvelope(session, sequence: 2))
+            ])));
+        await WaitForAsync(() => socket.SentTexts.Count >= 3);
+
+        using (var secondReplayCommand = JsonDocument.Parse(socket.SentTexts[2]))
+        {
+            var secondReplayRequest = secondReplayCommand.RootElement.GetProperty("data")
+                .Deserialize<MessageEnvelope<ReplayRequestPayload>>(SessionMessageSerializer.DefaultOptions);
+
+            Assert.NotNull(secondReplayRequest);
+            Assert.Equal(ReplayRequestReason.ClientRecovery, secondReplayRequest!.Payload.Reason);
+            Assert.Equal(3, secondReplayRequest.Payload.FromSequenceInclusive);
+            Assert.Equal(4, secondReplayRequest.Payload.ToSequenceInclusive);
+        }
+
+        socket.EnqueueIncoming(GroupMessage(CreateReplayResponseEnvelope(
+            session,
+            availableFromSequence: 1,
+            availableToSequence: 4,
+            messages:
+            [
+                ToJsonEnvelope(CreateBrokerEnvelope(session, sequence: 3)),
+                ToJsonEnvelope(CreateBrokerEnvelope(session, sequence: 4))
+            ])));
+        await WaitForAsync(() => service.CurrentStatus.State == MessageConnectionState.Connected && !service.CurrentStatus.IsReplayPending);
+
+        Assert.Equal(4, service.CurrentStatus.AcknowledgedSequence);
+        Assert.Contains(service.RecentTraffic, traffic => traffic.Direction == MessageTrafficDirection.Incoming && traffic.Envelope.Sequence == 4);
     }
 
     [Fact]
@@ -1002,6 +1106,7 @@ public sealed class PubSubConnectionServiceTests
         SessionDescriptor session,
         long generation = SessionEnvelopeContract.InitialGeneration,
         bool gapDetected = false,
+        bool hasMore = false,
         long? availableFromSequence = null,
         long? availableToSequence = null,
         IReadOnlyList<MessageEnvelope<JsonElement>>? messages = null,
@@ -1025,7 +1130,8 @@ public sealed class PubSubConnectionServiceTests
                 AvailableFromSequence = availableFromSequence,
                 AvailableToSequence = availableToSequence,
                 GapDetected = gapDetected,
-                IsComplete = true,
+                HasMore = hasMore,
+                IsComplete = !hasMore,
                 Messages = messages ?? Array.Empty<MessageEnvelope<JsonElement>>()
             }
         };

--- a/tests/SquadScout.App.Tests/SessionResumeServiceTests.cs
+++ b/tests/SquadScout.App.Tests/SessionResumeServiceTests.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+using SquadScout.App.Services;
+using SquadScout.Contracts.Messages;
+using SquadScout.Contracts.Projects;
+using SquadScout.Contracts.Sessions;
+
+namespace SquadScout.App.Tests;
+
+public sealed class SessionResumeServiceTests
+{
+    [Fact]
+    public async Task SaveAsync_ThenRestoreAsync_RehydratesSnapshotAndRecentTraffic()
+    {
+        var storagePath = CreateStoragePath();
+        var initialState = new ActiveSessionState();
+        var service = new SessionResumeService(storagePath, initialState);
+
+        var persisted = new ActiveSessionResumeState
+        {
+            Snapshot = new ActiveSessionSnapshot(
+                new RegisteredProject
+                {
+                    ProjectId = "squadscout",
+                    DisplayName = "SquadScout",
+                    RepositoryRoot = @"D:\GitHub\SquadScout"
+                },
+                new SessionDescriptor
+                {
+                    ProjectId = "squadscout",
+                    SessionId = "session-restore",
+                    State = SessionState.Running,
+                    CreatedAtUtc = new DateTimeOffset(2026, 03, 25, 11, 30, 00, TimeSpan.Zero)
+                },
+                SessionActivationSource.Broker,
+                "Persisted session."),
+            Connection = new MessageConnectionResumeState
+            {
+                Generation = 2,
+                AcknowledgedSequence = 5
+            },
+            RecentTraffic =
+            [
+                new MessageEnvelopeTraffic
+                {
+                    Direction = MessageTrafficDirection.Incoming,
+                    Summary = "output",
+                    Envelope = ToJsonEnvelope(new MessageEnvelope<OutputChunkPayload>
+                    {
+                        ProjectId = "squadscout",
+                        SessionId = "session-restore",
+                        Generation = 2,
+                        MessageType = SessionMessageType.Output,
+                        Direction = MessageDirection.BrokerToClient,
+                        Sequence = 5,
+                        TimestampUtc = DateTimeOffset.UtcNow,
+                        MessageId = "broker-5",
+                        CorrelationId = "corr",
+                        Payload = new OutputChunkPayload
+                        {
+                            Content = "restored output"
+                        }
+                    })
+                }
+            ]
+        };
+
+        await service.SaveAsync(persisted);
+
+        var restoredState = new ActiveSessionState();
+        var restoredService = new SessionResumeService(storagePath, restoredState);
+        await restoredService.RestoreAsync();
+
+        Assert.NotNull(restoredService.CurrentState);
+        Assert.Equal(2, restoredService.CurrentState!.Connection.Generation);
+        Assert.Equal(5, restoredService.CurrentState.Connection.AcknowledgedSequence);
+        Assert.Single(restoredService.CurrentState.RecentTraffic);
+        Assert.True(restoredState.GetSnapshot().HasActiveSession);
+        Assert.Contains("Recovered", restoredState.GetSnapshot().Summary, StringComparison.Ordinal);
+        Assert.Equal("session-restore", restoredState.GetSnapshot().Session?.SessionId);
+    }
+
+    [Fact]
+    public async Task ClearAsync_RemovesPersistedState()
+    {
+        var storagePath = CreateStoragePath();
+        var service = new SessionResumeService(storagePath, new ActiveSessionState());
+        await service.SaveAsync(new ActiveSessionResumeState
+        {
+            Snapshot = new ActiveSessionSnapshot(
+                new RegisteredProject
+                {
+                    ProjectId = "squadscout",
+                    DisplayName = "SquadScout",
+                    RepositoryRoot = @"D:\GitHub\SquadScout"
+                },
+                new SessionDescriptor
+                {
+                    ProjectId = "squadscout",
+                    SessionId = "session-clear",
+                    State = SessionState.Pending,
+                    CreatedAtUtc = DateTimeOffset.UtcNow
+                },
+                SessionActivationSource.Broker,
+                "Persisted session.")
+        });
+
+        Assert.True(File.Exists(storagePath));
+
+        await service.ClearAsync();
+
+        Assert.False(File.Exists(storagePath));
+        Assert.Null(service.CurrentState);
+    }
+
+    private static string CreateStoragePath() =>
+        Path.Combine(AppContext.BaseDirectory, "session-resume-tests", Guid.NewGuid().ToString("N"), "active-session.json");
+
+    private static MessageEnvelope<JsonElement> ToJsonEnvelope<TPayload>(MessageEnvelope<TPayload> envelope) =>
+        new()
+        {
+            ContractVersion = envelope.ContractVersion,
+            ProjectId = envelope.ProjectId,
+            SessionId = envelope.SessionId,
+            Generation = envelope.Generation,
+            MessageType = envelope.MessageType,
+            Direction = envelope.Direction,
+            Sequence = envelope.Sequence,
+            ClientSequence = envelope.ClientSequence,
+            AcknowledgedSequence = envelope.AcknowledgedSequence,
+            TimestampUtc = envelope.TimestampUtc,
+            MessageId = envelope.MessageId,
+            CorrelationId = envelope.CorrelationId,
+            CausationId = envelope.CausationId,
+            Payload = JsonSerializer.SerializeToElement(envelope.Payload, SessionMessageSerializer.DefaultOptions)
+        };
+}

--- a/tests/SquadScout.App.Tests/SessionTranscriptControllerTests.cs
+++ b/tests/SquadScout.App.Tests/SessionTranscriptControllerTests.cs
@@ -1,5 +1,7 @@
+using System.Text.Json;
 using SquadScout.App.Services;
 using SquadScout.App.ViewModels;
+using SquadScout.Contracts.Messages;
 using SquadScout.Contracts.Projects;
 using SquadScout.Contracts.Sessions;
 
@@ -152,6 +154,48 @@ public sealed class SessionTranscriptControllerTests
         Assert.Contains(result.ViewState.Banners, banner => banner.Title == "Live transport unavailable");
     }
 
+    [Fact]
+    public void ObserveTraffic_ReplayRecoveryAppendsSystemMessagesAndBrokerOutput()
+    {
+        var controller = new SessionTranscriptController();
+        var snapshot = CreateSnapshot(SessionState.Running, SessionActivationSource.Broker);
+        var connectionStatus = new MessageConnectionStatus
+        {
+            State = MessageConnectionState.Connected,
+            Summary = "Connected.",
+            Hub = "squadscout",
+            SupportsLiveSessionStream = true
+        };
+
+        controller.Sync(snapshot, connectionStatus);
+        controller.ObserveTraffic(snapshot, connectionStatus, CreateTraffic(CreateReplayRequest(ReplayRequestReason.ClientRecovery, 4)));
+        var state = controller.ObserveTraffic(snapshot, connectionStatus, CreateTraffic(CreateOutputEnvelope(sequence: 4, content: "Recovered output")));
+
+        Assert.Contains(state.Messages, message => message.IsSystem && message.Text.Contains("Recovering transcript messages from sequence 4", StringComparison.Ordinal));
+        Assert.Contains(state.Messages, message => !message.IsSystem && message.Text == "Recovered output");
+    }
+
+    [Fact]
+    public void RestoreFromTraffic_DeduplicatesPreviouslyPersistedReplayableMessages()
+    {
+        var controller = new SessionTranscriptController();
+        var snapshot = CreateSnapshot(SessionState.Running, SessionActivationSource.Broker);
+        var connectionStatus = new MessageConnectionStatus
+        {
+            State = MessageConnectionState.Connected,
+            Summary = "Connected.",
+            Hub = "squadscout",
+            SupportsLiveSessionStream = true
+        };
+
+        var traffic = CreateTraffic(CreateOutputEnvelope(sequence: 8, content: "Only once"));
+        controller.RestoreFromTraffic(snapshot, connectionStatus, [traffic]);
+        var state = controller.ObserveTraffic(snapshot, connectionStatus, traffic);
+
+        Assert.Single(state.Messages);
+        Assert.Equal("Only once", state.Messages[0].Text);
+    }
+
     private static ActiveSessionSnapshot CreateSnapshot(SessionState state, SessionActivationSource source)
     {
         return new ActiveSessionSnapshot(
@@ -171,4 +215,69 @@ public sealed class SessionTranscriptControllerTests
             source,
             "Active session");
     }
+
+    private static MessageEnvelopeTraffic CreateTraffic<TPayload>(MessageEnvelope<TPayload> envelope) =>
+        new()
+        {
+            Direction = envelope.Direction == MessageDirection.BrokerToClient
+                ? MessageTrafficDirection.Incoming
+                : MessageTrafficDirection.Outgoing,
+            Envelope = ToJsonEnvelope(envelope),
+            Summary = envelope.MessageType.ToString()
+        };
+
+    private static MessageEnvelope<ReplayRequestPayload> CreateReplayRequest(ReplayRequestReason reason, long fromSequenceInclusive) =>
+        new()
+        {
+            ProjectId = "squadscout",
+            SessionId = "session-10",
+            Generation = SessionEnvelopeContract.InitialGeneration,
+            MessageType = SessionMessageType.ReplayRequest,
+            Direction = MessageDirection.ClientToBroker,
+            TimestampUtc = DateTimeOffset.UtcNow,
+            MessageId = $"replay-{fromSequenceInclusive}",
+            CorrelationId = "corr",
+            Payload = new ReplayRequestPayload
+            {
+                FromSequenceInclusive = fromSequenceInclusive,
+                Reason = reason
+            }
+        };
+
+    private static MessageEnvelope<OutputChunkPayload> CreateOutputEnvelope(long sequence, string content) =>
+        new()
+        {
+            ProjectId = "squadscout",
+            SessionId = "session-10",
+            Generation = SessionEnvelopeContract.InitialGeneration,
+            MessageType = SessionMessageType.Output,
+            Direction = MessageDirection.BrokerToClient,
+            Sequence = sequence,
+            TimestampUtc = DateTimeOffset.UtcNow,
+            MessageId = $"broker-{sequence}",
+            CorrelationId = "corr",
+            Payload = new OutputChunkPayload
+            {
+                Content = content
+            }
+        };
+
+    private static MessageEnvelope<JsonElement> ToJsonEnvelope<TPayload>(MessageEnvelope<TPayload> envelope) =>
+        new()
+        {
+            ContractVersion = envelope.ContractVersion,
+            ProjectId = envelope.ProjectId,
+            SessionId = envelope.SessionId,
+            Generation = envelope.Generation,
+            MessageType = envelope.MessageType,
+            Direction = envelope.Direction,
+            Sequence = envelope.Sequence,
+            ClientSequence = envelope.ClientSequence,
+            AcknowledgedSequence = envelope.AcknowledgedSequence,
+            TimestampUtc = envelope.TimestampUtc,
+            MessageId = envelope.MessageId,
+            CorrelationId = envelope.CorrelationId,
+            CausationId = envelope.CausationId,
+            Payload = JsonSerializer.SerializeToElement(envelope.Payload, SessionMessageSerializer.DefaultOptions)
+        };
 }

--- a/tests/SquadScout.App.Tests/SquadScout.App.Tests.csproj
+++ b/tests/SquadScout.App.Tests/SquadScout.App.Tests.csproj
@@ -34,6 +34,7 @@
       <Compile Include="..\..\src\SquadScout.App\Services\WebPubSubBrokerControlServices.cs" Link="App\Services\WebPubSubBrokerControlServices.cs" />
       <Compile Include="..\..\src\SquadScout.App\Services\WebPubSubSocketClient.cs" Link="App\Services\WebPubSubSocketClient.cs" />
       <Compile Include="..\..\src\SquadScout.App\Services\MessagingConnectionService.cs" Link="App\Services\MessagingConnectionService.cs" />
+      <Compile Include="..\..\src\SquadScout.App\Services\SessionResumeService.cs" Link="App\Services\SessionResumeService.cs" />
    </ItemGroup>
 
 </Project>

--- a/tests/SquadScout.App.Tests/ViewModelTestDoubles.cs
+++ b/tests/SquadScout.App.Tests/ViewModelTestDoubles.cs
@@ -158,7 +158,7 @@ namespace SquadScout.App.Tests
 
         public Func<Task<MessageConnectionStatus>>? OnResetAsync { get; set; }
 
-        public Func<SessionDescriptor, Task<MessageConnectionStatus>>? OnPrepareForSessionAsync { get; set; }
+        public Func<SessionDescriptor, MessageConnectionResumeState?, Task<MessageConnectionStatus>>? OnPrepareForSessionAsync { get; set; }
 
         public int PrepareForSessionCallCount { get; private set; }
 
@@ -178,13 +178,16 @@ namespace SquadScout.App.Tests
             return Task.CompletedTask;
         }
 
-        public async Task<MessageConnectionStatus> PrepareForSessionAsync(SessionDescriptor session, CancellationToken cancellationToken = default)
+        public async Task<MessageConnectionStatus> PrepareForSessionAsync(
+            SessionDescriptor session,
+            MessageConnectionResumeState? resumeState = null,
+            CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             PrepareForSessionCallCount++;
             var status = OnPrepareForSessionAsync is null
                 ? _currentStatus
-                : await OnPrepareForSessionAsync(session);
+                : await OnPrepareForSessionAsync(session, resumeState);
 
             SetCurrentStatus(status);
             return status;
@@ -233,6 +236,47 @@ namespace SquadScout.App.Tests
         {
             _currentStatus = status;
             StatusChanged?.Invoke(this, status);
+        }
+    }
+
+    internal sealed class RecordingSessionResumeService : ISessionResumeService
+    {
+        public Func<Task>? OnRestoreAsync { get; set; }
+
+        public ActiveSessionResumeState? CurrentState { get; private set; }
+
+        public int ClearCallCount { get; private set; }
+
+        public int RestoreCallCount { get; private set; }
+
+        public int SaveCallCount { get; private set; }
+
+        public Task RestoreAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RestoreCallCount++;
+            return OnRestoreAsync?.Invoke() ?? Task.CompletedTask;
+        }
+
+        public Task SaveAsync(ActiveSessionResumeState state, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SaveCallCount++;
+            CurrentState = state;
+            return Task.CompletedTask;
+        }
+
+        public Task ClearAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ClearCallCount++;
+            CurrentState = null;
+            return Task.CompletedTask;
+        }
+
+        public void SetCurrentState(ActiveSessionResumeState? state)
+        {
+            CurrentState = state;
         }
     }
 


### PR DESCRIPTION
## Summary
- add persisted active-session resume state and restore it across app restarts
- recover transcript continuity through the existing replay contract, including replay paging and gap UX
- extend MAUI view models/controllers and app tests to cover reconnect, replay, and resume-first flows

## Validation
- dotnet build .\SquadScout.slnx -nologo
- dotnet test .\SquadScout.slnx -nologo --no-build

Closes #21