### PR TITLE
Implement token refresh session rejoin flow (#23)

### DIFF
--- a/src/SquadScout.App/Configuration/AppConfiguration.cs
+++ b/src/SquadScout.App/Configuration/AppConfiguration.cs
@@ -86,6 +86,24 @@ public static class AppConfiguration
         {
             options.Messaging.CommandAckTimeoutSeconds = commandAckTimeoutSeconds;
         }
+
+        var tokenRefreshRetryCount = Environment.GetEnvironmentVariable("SQUADSCOUT_MESSAGING__TOKENREFRESHRETRYCOUNT");
+        if (int.TryParse(tokenRefreshRetryCount, out var refreshRetryCount) && refreshRetryCount >= 0)
+        {
+            options.Messaging.TokenRefreshRetryCount = refreshRetryCount;
+        }
+
+        var tokenRefreshRetryBaseDelay = Environment.GetEnvironmentVariable("SQUADSCOUT_MESSAGING__TOKENREFRESHRETRYBASEDELAYSECONDS");
+        if (int.TryParse(tokenRefreshRetryBaseDelay, out var refreshRetryBaseDelaySeconds) && refreshRetryBaseDelaySeconds > 0)
+        {
+            options.Messaging.TokenRefreshRetryBaseDelaySeconds = refreshRetryBaseDelaySeconds;
+        }
+
+        var tokenRefreshRetryMaxDelay = Environment.GetEnvironmentVariable("SQUADSCOUT_MESSAGING__TOKENREFRESHRETRYMAXDELAYSECONDS");
+        if (int.TryParse(tokenRefreshRetryMaxDelay, out var refreshRetryMaxDelaySeconds) && refreshRetryMaxDelaySeconds > 0)
+        {
+            options.Messaging.TokenRefreshRetryMaxDelaySeconds = refreshRetryMaxDelaySeconds;
+        }
     }
 }
 
@@ -146,6 +164,12 @@ public sealed class MessagingOptions
     public int ConnectTimeoutSeconds { get; set; } = 15;
 
     public int CommandAckTimeoutSeconds { get; set; } = 10;
+
+    public int TokenRefreshRetryCount { get; set; } = 4;
+
+    public int TokenRefreshRetryBaseDelaySeconds { get; set; } = 5;
+
+    public int TokenRefreshRetryMaxDelaySeconds { get; set; } = 60;
 
     public int RecentTrafficCapacity { get; set; } = 200;
 }

--- a/src/SquadScout.App/Services/MessagingConnectionService.cs
+++ b/src/SquadScout.App/Services/MessagingConnectionService.cs
@@ -12,7 +12,6 @@ namespace SquadScout.App.Services;
 public sealed class MessagingConnectionService : IMessageConnectionService, IAsyncDisposable
 {
     private const string WebPubSubSubprotocol = "json.webpubsub.azure.v1";
-    private static readonly TimeSpan TokenRefreshLeadTime = TimeSpan.FromMinutes(5);
 
     private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
     private readonly MessagingOptions _messagingOptions;
@@ -1063,6 +1062,22 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
         }
     }
 
+    private PubSubNegotiateResponse? GetNegotiation()
+    {
+        lock (_stateSync)
+        {
+            return _negotiation;
+        }
+    }
+
+    private bool HasConnectedTransport()
+    {
+        lock (_stateSync)
+        {
+            return _socket is not null && _currentStatus.State == MessageConnectionState.Connected;
+        }
+    }
+
     private bool IsCurrentSession(SessionDescriptor session)
     {
         lock (_stateSync)
@@ -1158,46 +1173,110 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
 
     private async Task RefreshTokenAsync(CancellationToken cancellationToken)
     {
-        await _operationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        var retryCount = Math.Max(0, _messagingOptions.TokenRefreshRetryCount);
+        for (var attempt = 1; ; attempt++)
         {
-            var session = GetActiveSession();
-            if (session is null || CurrentStatus.State != MessageConnectionState.Connected)
-            {
-                return;
-            }
+            SessionDescriptor? session = null;
+            PubSubNegotiateResponse? activeNegotiation = null;
 
             try
             {
-                var negotiation = await _negotiationClient.NegotiateAsync(session, CancellationToken.None).ConfigureAwait(false);
-                await ConnectCoreAsync(
-                        isReconnect: true,
-                        reconnectAttempt: CurrentStatus.ReconnectAttempt,
-                        CancellationToken.None,
-                        negotiationOverride: negotiation,
-                        publishTransitionStatus: false,
-                        failureReasonPrefix: "Token refresh failed. Retry the live transport after confirming the broker negotiate endpoint is reachable.")
-                    .ConfigureAwait(false);
+                await _operationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    session = GetActiveSession();
+                    activeNegotiation = GetNegotiation();
+                    if (session is null || activeNegotiation is null)
+                    {
+                        return;
+                    }
+
+                    if (attempt == 1 && CurrentStatus.State != MessageConnectionState.Connected)
+                    {
+                        return;
+                    }
+
+                    if (attempt > 1 && CurrentStatus.State == MessageConnectionState.Disconnected)
+                    {
+                        return;
+                    }
+
+                    var negotiation = await _negotiationClient.NegotiateAsync(session, cancellationToken).ConfigureAwait(false);
+                    ValidateRefreshedNegotiation(session, activeNegotiation, negotiation);
+
+                    var status = await ConnectCoreAsync(
+                            isReconnect: true,
+                            reconnectAttempt: CurrentStatus.ReconnectAttempt,
+                            CancellationToken.None,
+                            negotiationOverride: negotiation,
+                            publishTransitionStatus: false,
+                            failureReasonPrefix: "Token refresh failed. Retry the live transport after confirming the broker negotiate endpoint is reachable.")
+                        .ConfigureAwait(false);
+
+                    if (status.State == MessageConnectionState.Connected)
+                    {
+                        return;
+                    }
+
+                    throw new InvalidOperationException(status.FailureReason ?? status.Summary);
+                }
+                finally
+                {
+                    _operationGate.Release();
+                }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 return;
             }
+            catch (TokenRefreshAuthDriftException driftException)
+            {
+                session ??= GetActiveSession();
+                if (session is null)
+                {
+                    return;
+                }
+
+                await FailTokenRefreshAsync(
+                        session,
+                        ComposeFailureReason(
+                            "Token refresh detected authentication drift. Retry the live transport after confirming the active account still owns this session.",
+                            driftException.Message))
+                    .ConfigureAwait(false);
+                return;
+            }
             catch (Exception ex)
             {
-                await CleanupTransportAsync(CancellationToken.None).ConfigureAwait(false);
-                PublishStatus(
-                    CreateFaultedStatus(
-                        session,
-                        CurrentStatus.ReconnectAttempt,
-                        ComposeFailureReason(
-                            "Token refresh failed. Retry the live transport after confirming the broker negotiate endpoint is reachable.",
-                            ex.Message)));
+                session ??= GetActiveSession();
+                activeNegotiation ??= GetNegotiation();
+                if (session is null || activeNegotiation is null)
+                {
+                    return;
+                }
+
+                if (attempt > retryCount)
+                {
+                    await FailTokenRefreshAsync(
+                            session,
+                            ComposeFailureReason(
+                                $"Token refresh failed after {attempt} attempt{(attempt == 1 ? string.Empty : "s")}. Retry the live transport after confirming the broker negotiate endpoint is reachable.",
+                                ex.Message))
+                        .ConfigureAwait(false);
+                    return;
+                }
+
+                var retryDelay = CalculateRefreshRetryDelay(activeNegotiation.ExpiresAtUtc, attempt);
+                PublishStatus(CreateTokenRefreshRetryStatus(session, activeNegotiation, attempt, retryDelay, ex.Message));
+
+                try
+                {
+                    await _delayAsync(retryDelay, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
             }
-        }
-        finally
-        {
-            _operationGate.Release();
         }
     }
 
@@ -1209,16 +1288,71 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             return TimeSpan.Zero;
         }
 
-        var fiveMinuteDelay = remaining - TokenRefreshLeadTime;
-        if (fiveMinuteDelay <= TimeSpan.Zero)
+        return remaining;
+    }
+
+    private TimeSpan CalculateRefreshRetryDelay(DateTimeOffset expiresAtUtc, int failedAttempt)
+    {
+        var baseDelaySeconds = Math.Max(1, _messagingOptions.TokenRefreshRetryBaseDelaySeconds);
+        var maxDelaySeconds = Math.Max(baseDelaySeconds, _messagingOptions.TokenRefreshRetryMaxDelaySeconds);
+        var multiplier = Math.Pow(2d, Math.Max(0, failedAttempt - 1));
+        var proposedDelay = TimeSpan.FromSeconds(Math.Min(maxDelaySeconds, baseDelaySeconds * multiplier));
+        if (expiresAtUtc == default)
+        {
+            return proposedDelay;
+        }
+
+        var remainingLifetime = expiresAtUtc - _utcNow();
+        if (remainingLifetime <= TimeSpan.FromSeconds(1))
         {
             return TimeSpan.Zero;
         }
 
-        var seventyFivePercentDelay = TimeSpan.FromTicks((long)(remaining.Ticks * 0.75d));
-        return fiveMinuteDelay < seventyFivePercentDelay
-            ? fiveMinuteDelay
-            : seventyFivePercentDelay;
+        var clampedDelay = remainingLifetime - TimeSpan.FromSeconds(1);
+        return proposedDelay <= clampedDelay
+            ? proposedDelay
+            : clampedDelay;
+    }
+
+    private void ValidateRefreshedNegotiation(
+        SessionDescriptor session,
+        PubSubNegotiateResponse currentNegotiation,
+        PubSubNegotiateResponse refreshedNegotiation)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(currentNegotiation);
+        ArgumentNullException.ThrowIfNull(refreshedNegotiation);
+
+        if (!string.Equals(refreshedNegotiation.ProjectId, session.ProjectId, StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(refreshedNegotiation.SessionId, session.SessionId, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new TokenRefreshAuthDriftException(
+                $"The negotiate endpoint returned credentials for {refreshedNegotiation.ProjectId}/{refreshedNegotiation.SessionId} instead of {session.ProjectId}/{session.SessionId}.");
+        }
+
+        if (!string.Equals(refreshedNegotiation.SessionGroup, currentNegotiation.SessionGroup, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new TokenRefreshAuthDriftException(
+                $"The negotiate endpoint returned session group '{refreshedNegotiation.SessionGroup}' instead of '{currentNegotiation.SessionGroup}'.");
+        }
+
+        if (!string.Equals(refreshedNegotiation.UserId, currentNegotiation.UserId, StringComparison.Ordinal))
+        {
+            throw new TokenRefreshAuthDriftException(
+                $"The negotiate endpoint returned user '{refreshedNegotiation.UserId}' instead of '{currentNegotiation.UserId}'.");
+        }
+
+        if (!string.Equals(refreshedNegotiation.Hub, currentNegotiation.Hub, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new TokenRefreshAuthDriftException(
+                $"The negotiate endpoint returned hub '{refreshedNegotiation.Hub}' instead of '{currentNegotiation.Hub}'.");
+        }
+    }
+
+    private async Task FailTokenRefreshAsync(SessionDescriptor session, string failureReason)
+    {
+        await CleanupTransportAsync(CancellationToken.None).ConfigureAwait(false);
+        PublishStatus(CreateFaultedStatus(session, CurrentStatus.ReconnectAttempt, failureReason));
     }
 
     private void PublishStatus(MessageConnectionStatus status)
@@ -1325,6 +1459,36 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             ReconnectAttempt = reconnectAttempt,
             FailureReason = failureReason
         });
+
+    private MessageConnectionStatus CreateTokenRefreshRetryStatus(
+        SessionDescriptor session,
+        PubSubNegotiateResponse negotiation,
+        int refreshAttempt,
+        TimeSpan retryDelay,
+        string detail)
+    {
+        var transportStillConnected = HasConnectedTransport();
+        var baseStatus = transportStillConnected
+            ? TryCreateConnectedStatus() ?? CurrentStatus
+            : CurrentStatus;
+        var summary = transportStillConnected
+            ? $"Refreshing live messaging for session '{session.SessionId}' hit a transient failure. Retrying in {FormatDelay(retryDelay)} while the current session stream stays connected."
+            : $"Refreshing live messaging for session '{session.SessionId}' lost the active session stream. Rejoining in {FormatDelay(retryDelay)}.";
+
+        return CreateStatusWithOrderingState(baseStatus with
+        {
+            State = transportStillConnected ? MessageConnectionState.Connected : MessageConnectionState.Reconnecting,
+            Summary = summary,
+            ProjectId = session.ProjectId,
+            SessionId = session.SessionId,
+            SessionGroup = negotiation.SessionGroup,
+            RefreshAtUtc = negotiation.RefreshAtUtc,
+            RefreshAttempt = refreshAttempt,
+            FailureReason = detail,
+            ReplayAvailableFromSequence = null,
+            ReplayAvailableToSequence = null
+        });
+    }
 
     private MessageConnectionStatus? TryCreateConnectedStatus()
     {
@@ -1494,6 +1658,21 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             ? detail
             : $"{prefix} {detail}";
 
+    private static string FormatDelay(TimeSpan delay)
+    {
+        if (delay <= TimeSpan.Zero)
+        {
+            return "0 seconds";
+        }
+
+        if (delay.TotalMinutes >= 1d && delay.Seconds == 0)
+        {
+            return $"{Math.Max(1, (int)Math.Round(delay.TotalMinutes, MidpointRounding.AwayFromZero))} minute(s)";
+        }
+
+        return $"{Math.Max(0, (int)Math.Ceiling(delay.TotalSeconds))} second(s)";
+    }
+
     private static MessageEnvelope<JsonElement> ToJsonEnvelope<TPayload>(MessageEnvelope<TPayload> envelope) =>
         new()
         {
@@ -1515,6 +1694,14 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
                     ? jsonPayload.Clone()
                     : JsonSerializer.SerializeToElement(envelope.Payload, SessionMessageSerializer.DefaultOptions))
         };
+
+    private sealed class TokenRefreshAuthDriftException : InvalidOperationException
+    {
+        public TokenRefreshAuthDriftException(string message)
+            : base(message)
+        {
+        }
+    }
 
     private sealed record WebPubSubJoinGroupCommand
     {

--- a/src/SquadScout.App/Services/PubSubNegotiationClient.cs
+++ b/src/SquadScout.App/Services/PubSubNegotiationClient.cs
@@ -79,12 +79,40 @@ public sealed class PubSubNegotiationClient : IPubSubNegotiationClient
         if (negotiateResponse is null ||
             string.IsNullOrWhiteSpace(negotiateResponse.Url) ||
             string.IsNullOrWhiteSpace(negotiateResponse.Hub) ||
+            string.IsNullOrWhiteSpace(negotiateResponse.UserId) ||
             string.IsNullOrWhiteSpace(negotiateResponse.SessionGroup))
         {
             throw new InvalidOperationException("Negotiate completed, but the response did not contain a usable Web PubSub connection payload.");
         }
 
+        ValidateNegotiateResponse(session, negotiateResponse);
         return negotiateResponse;
+    }
+
+    private static void ValidateNegotiateResponse(SessionDescriptor session, PubSubNegotiateResponse negotiateResponse)
+    {
+        if (!string.Equals(negotiateResponse.ProjectId, session.ProjectId, StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(negotiateResponse.SessionId, session.SessionId, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Negotiate completed, but the response targeted {negotiateResponse.ProjectId}/{negotiateResponse.SessionId} instead of {session.ProjectId}/{session.SessionId}.");
+        }
+
+        if (negotiateResponse.ParticipantKind != PubSubParticipantKind.Client)
+        {
+            throw new InvalidOperationException(
+                $"Negotiate completed, but the response granted '{negotiateResponse.ParticipantKind}' access instead of the expected client access.");
+        }
+
+        if (negotiateResponse.ExpiresAtUtc == default || negotiateResponse.RefreshAtUtc == default)
+        {
+            throw new InvalidOperationException("Negotiate completed, but the response did not include a usable token lifetime window.");
+        }
+
+        if (negotiateResponse.RefreshAtUtc >= negotiateResponse.ExpiresAtUtc)
+        {
+            throw new InvalidOperationException("Negotiate completed, but the token refresh window ends after the token expiry.");
+        }
     }
 
     private static async Task<string> TryReadErrorDetailAsync(HttpResponseMessage response, CancellationToken cancellationToken)

--- a/src/SquadScout.App/Services/ServiceContracts.cs
+++ b/src/SquadScout.App/Services/ServiceContracts.cs
@@ -62,6 +62,8 @@ public sealed record MessageConnectionStatus
 
     public int ReconnectAttempt { get; init; }
 
+    public int RefreshAttempt { get; init; }
+
     public string? FailureReason { get; init; }
 
     public long Generation { get; init; } = SessionEnvelopeContract.InitialGeneration;

--- a/src/SquadScout.App/appsettings.Development.json
+++ b/src/SquadScout.App/appsettings.Development.json
@@ -13,6 +13,9 @@
     "AutoPrepareOnSessionStart": true,
     "ConnectTimeoutSeconds": 10,
     "CommandAckTimeoutSeconds": 5,
+    "TokenRefreshRetryCount": 4,
+    "TokenRefreshRetryBaseDelaySeconds": 5,
+    "TokenRefreshRetryMaxDelaySeconds": 60,
     "RecentTrafficCapacity": 200
   },
   "LocalDevelopment": {

--- a/src/SquadScout.App/appsettings.json
+++ b/src/SquadScout.App/appsettings.json
@@ -13,6 +13,9 @@
     "AutoPrepareOnSessionStart": true,
     "ConnectTimeoutSeconds": 15,
     "CommandAckTimeoutSeconds": 10,
+    "TokenRefreshRetryCount": 4,
+    "TokenRefreshRetryBaseDelaySeconds": 5,
+    "TokenRefreshRetryMaxDelaySeconds": 60,
     "RecentTrafficCapacity": 200
   },
   "LocalDevelopment": {

--- a/tests/SquadScout.App.Tests/PubSubConnectionServiceTests.cs
+++ b/tests/SquadScout.App.Tests/PubSubConnectionServiceTests.cs
@@ -509,7 +509,7 @@ public sealed class PubSubConnectionServiceTests
     }
 
     [Fact]
-    public async Task PrepareForSessionAsyncSchedulesTokenRefreshBeforeRefreshAtUtc()
+    public async Task PrepareForSessionAsyncSchedulesTokenRefreshUsingFunctionRefreshWindow()
     {
         var session = CreateSession();
         var now = new DateTimeOffset(2026, 03, 25, 18, 00, 00, TimeSpan.Zero);
@@ -555,7 +555,7 @@ public sealed class PubSubConnectionServiceTests
 
         await service.PrepareForSessionAsync(session);
 
-        Assert.Equal(TimeSpan.FromMinutes(45), Assert.Single(delay.RequestedDelays));
+        Assert.Equal(TimeSpan.FromMinutes(60), Assert.Single(delay.RequestedDelays));
 
         delay.ReleaseNext();
 
@@ -566,7 +566,7 @@ public sealed class PubSubConnectionServiceTests
 
         await WaitForAsync(() => delay.RequestedDelays.Count >= 2);
 
-        Assert.Equal(TimeSpan.FromMinutes(90), delay.RequestedDelays[1]);
+        Assert.Equal(TimeSpan.FromMinutes(120), delay.RequestedDelays[1]);
     }
 
     [Fact]
@@ -636,6 +636,78 @@ public sealed class PubSubConnectionServiceTests
         Assert.NotNull(envelope);
         Assert.Equal(2, envelope!.AcknowledgedSequence);
         Assert.Equal(1, envelope.ClientSequence);
+    }
+
+    [Fact]
+    public async Task TokenRefreshRetriesNegotiateFailuresBeforeRejoiningSession()
+    {
+        var session = CreateSession();
+        var now = new DateTimeOffset(2026, 03, 25, 18, 00, 00, TimeSpan.Zero);
+        var delay = new ControlledDelay();
+        var firstSocket = new FakeWebPubSubSocket
+        {
+            ConnectFrames =
+            [
+                SystemMessage("connected", connectionId: "conn-refresh-retry-1")
+            ],
+            OnSendAsync = command =>
+            {
+                var json = JsonDocument.Parse(command);
+                var ackId = json.RootElement.GetProperty("ackId").GetInt64();
+                return Task.FromResult<string?>(AckMessage(ackId, success: true));
+            }
+        };
+
+        var secondSocket = new FakeWebPubSubSocket
+        {
+            ConnectFrames =
+            [
+                SystemMessage("connected", connectionId: "conn-refresh-retry-2")
+            ],
+            OnSendAsync = command =>
+            {
+                var json = JsonDocument.Parse(command);
+                var ackId = json.RootElement.GetProperty("ackId").GetInt64();
+                return Task.FromResult<string?>(AckMessage(ackId, success: true));
+            }
+        };
+
+        var negotiationClient = new ScriptedNegotiationClient(
+            CreateNegotiationResponse(session, refreshAtUtc: now.AddMinutes(10), expiresAtUtc: now.AddMinutes(20)),
+            new InvalidOperationException("Negotiate failed with 503 (ServiceUnavailable)."),
+            new InvalidOperationException("Negotiate failed with 503 (ServiceUnavailable)."),
+            CreateNegotiationResponse(session, refreshAtUtc: now.AddMinutes(30), expiresAtUtc: now.AddMinutes(40)));
+
+        await using var service = CreateService(
+            negotiationClient,
+            () => now,
+            delay.DelayAsync,
+            firstSocket,
+            secondSocket);
+
+        await service.PrepareForSessionAsync(session);
+
+        await WaitForAsync(() => delay.RequestedDelays.Count == 1);
+        delay.ReleaseNext();
+
+        await WaitForAsync(() => delay.RequestedDelays.Count == 2);
+        Assert.Equal(MessageConnectionState.Connected, service.CurrentStatus.State);
+        Assert.Equal(1, service.CurrentStatus.RefreshAttempt);
+        Assert.Contains("Retrying in 5 second", service.CurrentStatus.Summary, StringComparison.OrdinalIgnoreCase);
+
+        delay.ReleaseNext();
+        await WaitForAsync(() => delay.RequestedDelays.Count == 3);
+        Assert.Equal(MessageConnectionState.Connected, service.CurrentStatus.State);
+        Assert.Equal(2, service.CurrentStatus.RefreshAttempt);
+        Assert.Contains("Retrying in 10 second", service.CurrentStatus.Summary, StringComparison.OrdinalIgnoreCase);
+
+        delay.ReleaseNext();
+        await WaitForAsync(() =>
+            negotiationClient.CallCount == 4 &&
+            service.CurrentStatus.State == MessageConnectionState.Connected &&
+            service.CurrentStatus.ConnectionId == "conn-refresh-retry-2");
+
+        Assert.Equal(0, service.CurrentStatus.RefreshAttempt);
     }
 
     [Fact]
@@ -776,7 +848,7 @@ public sealed class PubSubConnectionServiceTests
     }
 
     [Fact]
-    public async Task TokenRefreshFailureTransitionsToFaultedWithActionableGuidance()
+    public async Task TokenRefreshFailureTransitionsToFaultedAfterConfiguredRetries()
     {
         var session = CreateSession();
         var now = new DateTimeOffset(2026, 03, 25, 18, 00, 00, TimeSpan.Zero);
@@ -795,9 +867,77 @@ public sealed class PubSubConnectionServiceTests
             }
         };
 
+        var messagingOptions = new MessagingOptions
+        {
+            Hub = "squadscout",
+            NegotiateUrl = "http://127.0.0.1:7071/api/negotiate",
+            ConnectTimeoutSeconds = 5,
+            CommandAckTimeoutSeconds = 5,
+            TokenRefreshRetryCount = 1,
+            TokenRefreshRetryBaseDelaySeconds = 5,
+            TokenRefreshRetryMaxDelaySeconds = 60,
+            RecentTrafficCapacity = 20
+        };
+
         var negotiationClient = new ScriptedNegotiationClient(
-            CreateNegotiationResponse(session, now.AddMinutes(10)),
+            CreateNegotiationResponse(session, refreshAtUtc: now.AddMinutes(10), expiresAtUtc: now.AddMinutes(20)),
+            new InvalidOperationException("Negotiate failed with 401 (Unauthorized). The negotiate endpoint requires a trusted identity."),
             new InvalidOperationException("Negotiate failed with 401 (Unauthorized). The negotiate endpoint requires a trusted identity."));
+
+        await using var service = CreateService(
+            messagingOptions,
+            negotiationClient,
+            () => now,
+            delay.DelayAsync,
+            firstSocket);
+
+        await service.PrepareForSessionAsync(session);
+
+        await WaitForAsync(() => delay.RequestedDelays.Count == 1);
+        delay.ReleaseNext();
+        await WaitForAsync(() => delay.RequestedDelays.Count == 2);
+        Assert.Equal(MessageConnectionState.Connected, service.CurrentStatus.State);
+        Assert.Equal(1, service.CurrentStatus.RefreshAttempt);
+
+        delay.ReleaseNext();
+
+        await WaitForAsync(() => service.CurrentStatus.State == MessageConnectionState.Faulted);
+
+        Assert.Equal(3, negotiationClient.CallCount);
+        Assert.Contains("Token refresh failed", service.CurrentStatus.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Token refresh failed", service.CurrentStatus.FailureReason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("after 2 attempts", service.CurrentStatus.FailureReason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Retry the live transport", service.CurrentStatus.FailureReason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("trusted identity", service.CurrentStatus.FailureReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task TokenRefreshAuthDriftFaultsBeforeRejoiningWrongSessionIdentity()
+    {
+        var session = CreateSession();
+        var now = new DateTimeOffset(2026, 03, 25, 18, 00, 00, TimeSpan.Zero);
+        var delay = new ControlledDelay();
+        var firstSocket = new FakeWebPubSubSocket
+        {
+            ConnectFrames =
+            [
+                SystemMessage("connected", connectionId: "conn-auth-drift")
+            ],
+            OnSendAsync = command =>
+            {
+                var json = JsonDocument.Parse(command);
+                var ackId = json.RootElement.GetProperty("ackId").GetInt64();
+                return Task.FromResult<string?>(AckMessage(ackId, success: true));
+            }
+        };
+
+        var negotiationClient = new ScriptedNegotiationClient(
+            CreateNegotiationResponse(session, refreshAtUtc: now.AddMinutes(10), expiresAtUtc: now.AddMinutes(20)),
+            CreateNegotiationResponse(
+                session,
+                refreshAtUtc: now.AddMinutes(30),
+                expiresAtUtc: now.AddMinutes(40),
+                userId: $"client:{session.ProjectId}:{session.SessionId}:other-user"));
 
         await using var service = CreateService(
             negotiationClient,
@@ -812,10 +952,9 @@ public sealed class PubSubConnectionServiceTests
 
         await WaitForAsync(() => service.CurrentStatus.State == MessageConnectionState.Faulted);
 
-        Assert.Contains("Token refresh failed", service.CurrentStatus.Summary, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Token refresh failed", service.CurrentStatus.FailureReason, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Retry the live transport", service.CurrentStatus.FailureReason, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("trusted identity", service.CurrentStatus.FailureReason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("authentication drift", service.CurrentStatus.FailureReason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("other-user", service.CurrentStatus.FailureReason, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(WebSocketState.Closed, firstSocket.State);
     }
 
     [Fact]
@@ -867,6 +1006,40 @@ public sealed class PubSubConnectionServiceTests
         Assert.Equal("seraph@local", Assert.Single(users));
         Assert.True(capturedRequest.Headers.TryGetValues("x-squadscout-dev-name", out var displayNames));
         Assert.Equal("seraph@local", Assert.Single(displayNames));
+    }
+
+    [Fact]
+    public async Task PubSubNegotiationClientRejectsMismatchedScopedResponses()
+    {
+        using var httpClient = new HttpClient(new DelegateHttpMessageHandler(_ =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(
+                    CreateNegotiationResponse(
+                        CreateSession(),
+                        userId: "client:proj-01:session-other:mobile-user") with
+                    {
+                        SessionId = "session-other"
+                    },
+                    options: SessionMessageSerializer.DefaultOptions)
+            })));
+
+        var client = new PubSubNegotiationClient(
+            httpClient,
+            new MessagingOptions
+            {
+                NegotiateUrl = "http://127.0.0.1:7071/api/negotiate"
+            },
+            new ConfiguredAuthenticationService(new AuthOptions
+            {
+                Mode = "LocalDevelopment",
+                DefaultRequestedBy = "seraph@local"
+            }));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => client.NegotiateAsync(CreateSession()));
+
+        Assert.Contains("session-other", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("session-abc", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -1127,17 +1300,21 @@ public sealed class PubSubConnectionServiceTests
 
     private static PubSubNegotiateResponse CreateNegotiationResponse(
         SessionDescriptor session,
-        DateTimeOffset? refreshAtUtc = null) =>
+        DateTimeOffset? refreshAtUtc = null,
+        DateTimeOffset? expiresAtUtc = null,
+        string? userId = null,
+        string? sessionGroup = null,
+        string? hub = null) =>
         new()
         {
             Url = "wss://example.webpubsub.azure.com/client/hubs/squadscout?access_token=test",
-            Hub = "squadscout",
-            UserId = $"client:{session.ProjectId}:{session.SessionId}:mobile-user",
+            Hub = hub ?? "squadscout",
+            UserId = userId ?? $"client:{session.ProjectId}:{session.SessionId}:mobile-user",
             ProjectId = session.ProjectId,
             SessionId = session.SessionId,
             ParticipantKind = PubSubParticipantKind.Client,
-            SessionGroup = $"session:{session.ProjectId}:{session.SessionId}",
-            ExpiresAtUtc = DateTimeOffset.UtcNow.AddHours(1),
+            SessionGroup = sessionGroup ?? $"session:{session.ProjectId}:{session.SessionId}",
+            ExpiresAtUtc = expiresAtUtc ?? DateTimeOffset.UtcNow.AddHours(1),
             RefreshAtUtc = refreshAtUtc ?? DateTimeOffset.UtcNow.AddMinutes(50)
         };
 


### PR DESCRIPTION
## Summary
- honor Function-issued refresh windows and retry token refresh before expiry
- validate refreshed negotiate responses to catch auth drift before rejoining
- reuse reconnect/replay resume flow so refreshed sessions rejoin cleanly without losing ordering

## Testing
- dotnet build .\\SquadScout.slnx -nologo
- dotnet test .\\SquadScout.slnx -nologo --no-build

Closes #23