### PR TITLE
feat: add heartbeat liveness timeouts

### DIFF
--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -4,6 +4,7 @@
 
 - **2026-03-26: User directive.** By Ryan Graham (via Copilot). For Phase 2 work, keep work on separate branches, reference the issue in commit messages and PR messages, and only merge when the branch is clean.
 - **2026-03-26: Neo — Phase 2 Execution Map.** Dependency-correct 5-wave plan for all 9 open Phase 2 issues. Critical path: #18 → #19 → #21 → {#22 ‖ #23} → #24. Wave 0 starts now: Link → #18, Switch → #54, Switch → #55. Decision: #55 starts immediately (zero Orleans dependency, orthogonal to #54). Full map in `.squad/decisions/inbox/neo-phase2-map.md`.
+- **2026-03-26: Morpheus — Issue #22 Heartbeat & Liveness Model.** Keep replay/ack state on the top-level envelope, but extend `HeartbeatPayload` with broker-issued nonce challenge/ack fields plus shared interval/timeout metadata. Broker liveness tracking lives beside the PTY relay (not inside grains), times out on missing accepted client activity, and emits non-replayable heartbeat frames. The MAUI transport answers heartbeat challenges on the existing upstream path, faults the live transport when broker heartbeats expire, and preserves reconnect-by-replay semantics rather than inventing a second recovery contract.
 
 ## 2026-03-25
 
@@ -283,7 +284,7 @@ dotnet test .\SquadScout.slnx -nologo --no-build
 **Key decisions:**
 
 - Acknowledgement remains top-level `AcknowledgedSequence` (single source of truth)
-- Heartbeat payloads carry only liveness metadata (`ReplayRequested`, `ExpectedIntervalSeconds`, `SenderInstanceId`) to avoid duplicate ack state
+- Heartbeat payloads carry liveness metadata plus nonce challenge/ack fields; broker sequence ack remains top-level `AcknowledgedSequence`
 - Replay responses explicitly publish requested range and available window (`AvailableFromSequence`, `AvailableToSequence`, `GapDetected`) so reconnect overflow is explicit
 - Backward compatibility rule for contract version 1: additive optional members and new message types allowed; renames, removals, or sequence/ack semantic changes require major version bump
 

--- a/src/SquadScout.App/Services/MessagingConnectionService.cs
+++ b/src/SquadScout.App/Services/MessagingConnectionService.cs
@@ -605,7 +605,8 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             return true;
         }
 
-        await SendHeartbeatAcknowledgementAsync(payload, cancellationToken).ConfigureAwait(false);
+        var acknowledgement = CreateHeartbeatAcknowledgementEnvelope(payload);
+        QueueHeartbeatAcknowledgement(acknowledgement, cancellationToken);
         return true;
     }
 
@@ -951,16 +952,13 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
         }
     }
 
-    private async Task SendHeartbeatAcknowledgementAsync(
-        HeartbeatPayload brokerHeartbeat,
-        CancellationToken cancellationToken)
+    private MessageEnvelope<HeartbeatPayload> CreateHeartbeatAcknowledgementEnvelope(HeartbeatPayload brokerHeartbeat)
     {
         if (string.IsNullOrWhiteSpace(brokerHeartbeat.Nonce))
         {
             throw new InvalidOperationException("Broker heartbeat acknowledgements require a nonce.");
         }
 
-        MessageEnvelope<HeartbeatPayload> heartbeat;
         lock (_stateSync)
         {
             if (_activeSession is null)
@@ -969,7 +967,7 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             }
 
             var nextClientSequence = ++_nextClientSequence;
-            heartbeat = new MessageEnvelope<HeartbeatPayload>
+            return new MessageEnvelope<HeartbeatPayload>
             {
                 ProjectId = _activeSession.ProjectId,
                 SessionId = _activeSession.SessionId,
@@ -983,7 +981,7 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
                 CorrelationId = $"mobile-session:{_activeSession.SessionId}",
                 Payload = new HeartbeatPayload
                 {
-                    ReplayRequested = CurrentStatus.IsReplayPending,
+                    ReplayRequested = _currentStatus.IsReplayPending,
                     ExpectedIntervalSeconds = brokerHeartbeat.ExpectedIntervalSeconds,
                     LivenessTimeoutSeconds = brokerHeartbeat.LivenessTimeoutSeconds,
                     SenderInstanceId = _clientInstanceId,
@@ -991,15 +989,37 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
                 }
             };
         }
+    }
 
-        await _operationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+    private void QueueHeartbeatAcknowledgement(
+        MessageEnvelope<HeartbeatPayload> heartbeat,
+        CancellationToken cancellationToken)
+    {
+        _ = RunHeartbeatAcknowledgementAsync(heartbeat, cancellationToken);
+    }
+
+    private async Task RunHeartbeatAcknowledgementAsync(
+        MessageEnvelope<HeartbeatPayload> heartbeat,
+        CancellationToken cancellationToken)
+    {
         try
         {
-            await SendEnvelopeCoreAsync(heartbeat, requireConnectedStatus: true, cancellationToken).ConfigureAwait(false);
+            await _operationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await SendEnvelopeCoreAsync(heartbeat, requireConnectedStatus: true, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _operationGate.Release();
+            }
         }
-        finally
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            _operationGate.Release();
+        }
+        catch (Exception ex)
+        {
+            PublishReceiveFault($"The live session stream could not acknowledge heartbeat: {ex.Message}");
         }
     }
 
@@ -1384,14 +1404,23 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
 
             if (deadlineUtc is null)
             {
-                return;
+                try
+                {
+                    await _delayAsync(TimeSpan.FromMilliseconds(100), cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                continue;
             }
 
             var delay = deadlineUtc.Value - _utcNow();
             if (delay <= TimeSpan.Zero)
             {
-                await HandleBrokerHeartbeatTimeoutAsync().ConfigureAwait(false);
-                return;
+                await HandleBrokerHeartbeatTimeoutAsync(deadlineUtc.Value).ConfigureAwait(false);
+                continue;
             }
 
             try
@@ -1402,19 +1431,45 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             {
                 return;
             }
+
+            bool shouldTimeout;
+            lock (_stateSync)
+            {
+                shouldTimeout = _brokerHeartbeatDeadlineUtc is DateTimeOffset currentDeadlineUtc &&
+                                currentDeadlineUtc == deadlineUtc.Value &&
+                                currentDeadlineUtc <= _utcNow();
+            }
+
+            if (!shouldTimeout)
+            {
+                continue;
+            }
+
+            await HandleBrokerHeartbeatTimeoutAsync(deadlineUtc.Value).ConfigureAwait(false);
         }
     }
 
-    private async Task HandleBrokerHeartbeatTimeoutAsync()
+    private async Task HandleBrokerHeartbeatTimeoutAsync(DateTimeOffset expectedDeadlineUtc)
     {
-        var session = GetActiveSession();
-        if (session is null)
+        SessionDescriptor? session;
+        int reconnectAttempt;
+        lock (_stateSync)
         {
-            return;
+            if (_activeSession is null ||
+                _currentStatus.State != MessageConnectionState.Connected ||
+                _brokerHeartbeatDeadlineUtc is not DateTimeOffset currentDeadlineUtc ||
+                currentDeadlineUtc != expectedDeadlineUtc ||
+                currentDeadlineUtc > _utcNow())
+            {
+                return;
+            }
+
+            session = _activeSession;
+            reconnectAttempt = _currentStatus.ReconnectAttempt;
         }
 
         await CleanupTransportAsync(CancellationToken.None, skipAwaitLivenessMonitor: true).ConfigureAwait(false);
-        PublishStatus(CreateFaultedStatus(session, CurrentStatus.ReconnectAttempt, HeartbeatTimeoutFailureReason));
+        PublishStatus(CreateFaultedStatus(session, reconnectAttempt, HeartbeatTimeoutFailureReason));
     }
 
     private void PublishStatus(MessageConnectionStatus status)

--- a/src/SquadScout.App/Services/MessagingConnectionService.cs
+++ b/src/SquadScout.App/Services/MessagingConnectionService.cs
@@ -13,6 +13,8 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
 {
     private const string WebPubSubSubprotocol = "json.webpubsub.azure.v1";
     private static readonly TimeSpan TokenRefreshLeadTime = TimeSpan.FromMinutes(5);
+    private const string HeartbeatTimeoutFailureReason =
+        "The broker heartbeat timed out before the session stream could confirm liveness. Retry live transport to reconnect and request replay.";
 
     private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
     private readonly MessagingOptions _messagingOptions;
@@ -27,6 +29,8 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
     private PubSubNegotiateResponse? _negotiation;
     private CancellationTokenSource? _refreshLoopCts;
     private Task? _refreshLoopTask;
+    private CancellationTokenSource? _livenessMonitorCts;
+    private Task? _livenessMonitorTask;
     private IWebPubSubSocket? _socket;
     private CancellationTokenSource? _receiveLoopCts;
     private Task? _receiveLoopTask;
@@ -41,8 +45,10 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
     private readonly HashSet<long> _observedBrokerSequences = new();
     private readonly HashSet<long> _appliedBrokerSequences = new();
     private readonly HashSet<string> _appliedReplayResponseMessageIds = new(StringComparer.Ordinal);
+    private readonly string _clientInstanceId = $"mobile-{Guid.NewGuid():n}";
     private bool _gapDetected;
     private bool _replayRequestPending;
+    private DateTimeOffset? _brokerHeartbeatDeadlineUtc;
 
     public MessagingConnectionService(
         MessagingOptions messagingOptions,
@@ -515,6 +521,11 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             return true;
         }
 
+        if (envelope.MessageType == SessionMessageType.Heartbeat)
+        {
+            return await ProcessBrokerHeartbeatAsync(envelope, tracking, cancellationToken).ConfigureAwait(false);
+        }
+
         if (envelope.MessageType == SessionMessageType.ReplayResponse)
         {
             return await ApplyReplayResponseAsync(envelope, tracking, cancellationToken).ConfigureAwait(false);
@@ -544,6 +555,57 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             QueueReplayRequest(ReplayRequestReason.GapDetected, cancellationToken);
         }
 
+        return true;
+    }
+
+    private async Task<bool> ProcessBrokerHeartbeatAsync(
+        MessageEnvelope<JsonElement> envelope,
+        BrokerEnvelopeTrackingResult tracking,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var payload = envelope.Payload.Deserialize<HeartbeatPayload>(SessionMessageSerializer.DefaultOptions)
+            ?? throw new InvalidOperationException("Azure Web PubSub delivered a malformed heartbeat payload.");
+
+        if (string.IsNullOrWhiteSpace(payload.Nonce))
+        {
+            PublishReceiveFault("The live session stream delivered a heartbeat without a nonce challenge.");
+            return false;
+        }
+
+        var timeoutSeconds = payload.LivenessTimeoutSeconds ?? SessionHeartbeatDefaults.LivenessTimeoutSeconds;
+        if (timeoutSeconds <= 0)
+        {
+            PublishReceiveFault("The live session stream delivered a heartbeat with an invalid liveness timeout.");
+            return false;
+        }
+
+        if (tracking.ShouldAppend)
+        {
+            AppendTraffic(
+                new MessageEnvelopeTraffic
+                {
+                    Direction = MessageTrafficDirection.Incoming,
+                    Envelope = ToJsonEnvelope(envelope),
+                    ObservedAtUtc = _utcNow(),
+                    Summary = $"Received heartbeat for session '{envelope.SessionId}'."
+                });
+        }
+
+        lock (_stateSync)
+        {
+            _brokerHeartbeatDeadlineUtc = _utcNow().AddSeconds(timeoutSeconds);
+        }
+
+        EnsureHeartbeatMonitorStarted();
+
+        if (CurrentStatus.State != MessageConnectionState.Connected)
+        {
+            return true;
+        }
+
+        await SendHeartbeatAcknowledgementAsync(payload, cancellationToken).ConfigureAwait(false);
         return true;
     }
 
@@ -889,6 +951,58 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
         }
     }
 
+    private async Task SendHeartbeatAcknowledgementAsync(
+        HeartbeatPayload brokerHeartbeat,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(brokerHeartbeat.Nonce))
+        {
+            throw new InvalidOperationException("Broker heartbeat acknowledgements require a nonce.");
+        }
+
+        MessageEnvelope<HeartbeatPayload> heartbeat;
+        lock (_stateSync)
+        {
+            if (_activeSession is null)
+            {
+                throw new InvalidOperationException("An active session is required before heartbeat acknowledgements can be sent.");
+            }
+
+            var nextClientSequence = ++_nextClientSequence;
+            heartbeat = new MessageEnvelope<HeartbeatPayload>
+            {
+                ProjectId = _activeSession.ProjectId,
+                SessionId = _activeSession.SessionId,
+                Generation = _currentGeneration,
+                MessageType = SessionMessageType.Heartbeat,
+                Direction = MessageDirection.ClientToBroker,
+                ClientSequence = nextClientSequence,
+                AcknowledgedSequence = _acknowledgedSequence,
+                TimestampUtc = _utcNow(),
+                MessageId = $"heartbeat-{_activeSession.SessionId}-{nextClientSequence}",
+                CorrelationId = $"mobile-session:{_activeSession.SessionId}",
+                Payload = new HeartbeatPayload
+                {
+                    ReplayRequested = CurrentStatus.IsReplayPending,
+                    ExpectedIntervalSeconds = brokerHeartbeat.ExpectedIntervalSeconds,
+                    LivenessTimeoutSeconds = brokerHeartbeat.LivenessTimeoutSeconds,
+                    SenderInstanceId = _clientInstanceId,
+                    AcknowledgedNonce = brokerHeartbeat.Nonce
+                }
+            };
+        }
+
+        await _operationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await SendEnvelopeCoreAsync(heartbeat, requireConnectedStatus: true, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _operationGate.Release();
+        }
+    }
+
     private async Task SendJoinGroupAsync(IWebPubSubSocket socket, string sessionGroup, CancellationToken cancellationToken)
     {
         var ackId = Interlocked.Increment(ref _nextAckId);
@@ -979,9 +1093,11 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             });
     }
 
-    private async Task CleanupTransportAsync(CancellationToken cancellationToken)
+    private async Task CleanupTransportAsync(CancellationToken cancellationToken, bool skipAwaitLivenessMonitor = false)
     {
         CancellationTokenSource? refreshLoopCts;
+        CancellationTokenSource? livenessMonitorCts;
+        Task? livenessMonitorTask;
         IWebPubSubSocket? socket;
         CancellationTokenSource? receiveLoopCts;
         Task? receiveLoopTask;
@@ -991,6 +1107,10 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             refreshLoopCts = _refreshLoopCts;
             _refreshLoopTask = null;
             _refreshLoopCts = null;
+            livenessMonitorCts = _livenessMonitorCts;
+            livenessMonitorTask = _livenessMonitorTask;
+            _livenessMonitorCts = null;
+            _livenessMonitorTask = null;
             socket = _socket;
             receiveLoopCts = _receiveLoopCts;
             receiveLoopTask = _receiveLoopTask;
@@ -998,6 +1118,7 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             _receiveLoopCts = null;
             _receiveLoopTask = null;
             _connectionId = null;
+            _brokerHeartbeatDeadlineUtc = null;
         }
 
         foreach (var (_, pendingAck) in _pendingAcks.ToArray())
@@ -1007,6 +1128,7 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
 
         _pendingAcks.Clear();
         refreshLoopCts?.Cancel();
+        livenessMonitorCts?.Cancel();
         receiveLoopCts?.Cancel();
 
         if (socket is not null)
@@ -1037,7 +1159,19 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             }
         }
 
+        if (!skipAwaitLivenessMonitor && livenessMonitorTask is not null)
+        {
+            try
+            {
+                await livenessMonitorTask.ConfigureAwait(false);
+            }
+            catch
+            {
+            }
+        }
+
         refreshLoopCts?.Dispose();
+        livenessMonitorCts?.Dispose();
         receiveLoopCts?.Dispose();
     }
 
@@ -1088,6 +1222,7 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
             ResetBrokerOrderingStateLocked(SessionEnvelopeContract.InitialGeneration);
             _nextAckId = 0;
             _nextClientSequence = 0;
+            _brokerHeartbeatDeadlineUtc = null;
             if (clearTraffic)
             {
                 _recentTraffic = [];
@@ -1219,6 +1354,67 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
         return fiveMinuteDelay < seventyFivePercentDelay
             ? fiveMinuteDelay
             : seventyFivePercentDelay;
+    }
+
+    private void EnsureHeartbeatMonitorStarted()
+    {
+        lock (_stateSync)
+        {
+            if (_livenessMonitorTask is not null && !_livenessMonitorTask.IsCompleted)
+            {
+                return;
+            }
+
+            _livenessMonitorCts = new CancellationTokenSource();
+            _livenessMonitorTask = Task.Run(
+                () => MonitorHeartbeatTimeoutAsync(_livenessMonitorCts.Token),
+                CancellationToken.None);
+        }
+    }
+
+    private async Task MonitorHeartbeatTimeoutAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            DateTimeOffset? deadlineUtc;
+            lock (_stateSync)
+            {
+                deadlineUtc = _brokerHeartbeatDeadlineUtc;
+            }
+
+            if (deadlineUtc is null)
+            {
+                return;
+            }
+
+            var delay = deadlineUtc.Value - _utcNow();
+            if (delay <= TimeSpan.Zero)
+            {
+                await HandleBrokerHeartbeatTimeoutAsync().ConfigureAwait(false);
+                return;
+            }
+
+            try
+            {
+                await _delayAsync(delay, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+        }
+    }
+
+    private async Task HandleBrokerHeartbeatTimeoutAsync()
+    {
+        var session = GetActiveSession();
+        if (session is null)
+        {
+            return;
+        }
+
+        await CleanupTransportAsync(CancellationToken.None, skipAwaitLivenessMonitor: true).ConfigureAwait(false);
+        PublishStatus(CreateFaultedStatus(session, CurrentStatus.ReconnectAttempt, HeartbeatTimeoutFailureReason));
     }
 
     private void PublishStatus(MessageConnectionStatus status)
@@ -1481,6 +1677,7 @@ public sealed class MessagingConnectionService : IMessageConnectionService, IAsy
     private static string ResolveUpstreamEventName(SessionMessageType messageType) =>
         messageType switch
         {
+            SessionMessageType.Heartbeat => SessionUpstreamEventNames.Heartbeat,
             SessionMessageType.Input => SessionUpstreamEventNames.Input,
             SessionMessageType.ReplayRequest => SessionUpstreamEventNames.ReplayRequest,
             _ => throw new ArgumentOutOfRangeException(

--- a/src/SquadScout.Broker/Program.cs
+++ b/src/SquadScout.Broker/Program.cs
@@ -86,10 +86,12 @@ else
 }
 
 builder.Services.AddSingleton(orleansStatus);
+builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<InMemoryProjectCatalog>();
 builder.Services.AddSingleton<IPtyHost, CopilotPtyHost>();
 builder.Services.AddSingleton<PtySessionEnvelopePump>();
 builder.Services.AddSingleton<ISessionGroupResolver, SessionGroupResolver>();
+builder.Services.AddSingleton<ISessionLivenessManager, SessionLivenessManager>();
 builder.Services.AddSingleton<IRelayPublisher>(serviceProvider =>
 {
     var options = serviceProvider.GetRequiredService<IOptions<AzureWebPubSubOptions>>().Value;

--- a/src/SquadScout.Broker/Realtime/WebPubSubUpstreamHandler.cs
+++ b/src/SquadScout.Broker/Realtime/WebPubSubUpstreamHandler.cs
@@ -17,12 +17,14 @@ public sealed class WebPubSubUpstreamHandler
     public const string CloudEventTypeHeaderName = "ce-type";
     public const string CloudEventConnectionIdHeaderName = "ce-connectionId";
 
+    private static readonly string HeartbeatCloudEventType = $"azure.webpubsub.user.{SessionUpstreamEventNames.Heartbeat}";
     private static readonly string InputCloudEventType = $"azure.webpubsub.user.{SessionUpstreamEventNames.Input}";
     private static readonly string ReplayCloudEventType = $"azure.webpubsub.user.{SessionUpstreamEventNames.ReplayRequest}";
 
     private readonly WebPubSubUpstreamAuthenticator _authenticator;
     private readonly ISessionRelay _sessionRelay;
     private readonly ISessionOrchestrator _orchestrator;
+    private readonly ISessionLivenessManager _livenessManager;
     private readonly IRelayPublisher _relayPublisher;
     private readonly ILogger<WebPubSubUpstreamHandler> _logger;
 
@@ -30,12 +32,14 @@ public sealed class WebPubSubUpstreamHandler
         WebPubSubUpstreamAuthenticator authenticator,
         ISessionRelay sessionRelay,
         ISessionOrchestrator orchestrator,
+        ISessionLivenessManager livenessManager,
         IRelayPublisher relayPublisher,
         ILogger<WebPubSubUpstreamHandler> logger)
     {
         _authenticator = authenticator ?? throw new ArgumentNullException(nameof(authenticator));
         _sessionRelay = sessionRelay ?? throw new ArgumentNullException(nameof(sessionRelay));
         _orchestrator = orchestrator ?? throw new ArgumentNullException(nameof(orchestrator));
+        _livenessManager = livenessManager ?? throw new ArgumentNullException(nameof(livenessManager));
         _relayPublisher = relayPublisher ?? throw new ArgumentNullException(nameof(relayPublisher));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -130,10 +134,79 @@ public sealed class WebPubSubUpstreamHandler
 
         return envelope.MessageType switch
         {
+            SessionMessageType.Heartbeat => await HandleHeartbeatAsync(jsonBody, sessionGroup, connectionId, allowedOrigin, cancellationToken).ConfigureAwait(false),
             SessionMessageType.Input => await HandleInputAsync(jsonBody, sessionGroup, connectionId, allowedOrigin, cancellationToken).ConfigureAwait(false),
             SessionMessageType.ReplayRequest => await HandleReplayAsync(jsonBody, sessionGroup, connectionId, allowedOrigin, cancellationToken).ConfigureAwait(false),
-            _ => Error(HttpStatusCode.BadRequest, allowedOrigin, "The upstream request must contain an input or replay-request envelope.")
+            _ => Error(HttpStatusCode.BadRequest, allowedOrigin, "The upstream request must contain a heartbeat, input, or replay-request envelope.")
         };
+    }
+
+    private async Task<WebPubSubUpstreamResponse> HandleHeartbeatAsync(
+        string jsonBody,
+        string sessionGroup,
+        string? connectionId,
+        string? allowedOrigin,
+        CancellationToken cancellationToken)
+    {
+        MessageEnvelope<HeartbeatPayload>? envelope;
+        try
+        {
+            envelope = JsonSerializer.Deserialize<MessageEnvelope<HeartbeatPayload>>(jsonBody, SessionMessageSerializer.DefaultOptions);
+        }
+        catch (Exception exception) when (exception is JsonException or NotSupportedException)
+        {
+            return Error(HttpStatusCode.BadRequest, allowedOrigin, "The upstream request body must be a valid JSON heartbeat envelope.");
+        }
+
+        if (envelope?.Payload is null)
+        {
+            return Error(HttpStatusCode.BadRequest, allowedOrigin, "The upstream request body is required.");
+        }
+
+        if (envelope.MessageType != SessionMessageType.Heartbeat)
+        {
+            return Error(HttpStatusCode.BadRequest, allowedOrigin, "The upstream request must contain a heartbeat envelope.");
+        }
+
+        if (!_livenessManager.CanAcceptHeartbeat(envelope.SessionId, envelope.Payload, out var validationError))
+        {
+            _logger.LogWarning(
+                "Rejected Azure Web PubSub heartbeat {MessageId} for project {ProjectId} session {SessionId} through session group {SessionGroup} from connection {ConnectionId}: {FailureMessage}",
+                envelope.MessageId,
+                envelope.ProjectId,
+                envelope.SessionId,
+                sessionGroup,
+                connectionId ?? "<missing>",
+                validationError);
+
+            return Error(HttpStatusCode.BadRequest, allowedOrigin, validationError);
+        }
+
+        try
+        {
+            var validation = await _orchestrator.ValidateClientMessageAsync(envelope.SessionId, envelope, cancellationToken).ConfigureAwait(false);
+            if (validation.IsAccepted && validation.Status != SequenceValidationStatus.Duplicate)
+            {
+                if (!_livenessManager.TryCommitHeartbeat(envelope.SessionId, envelope.Payload))
+                {
+                    return Error(HttpStatusCode.BadRequest, allowedOrigin, "Heartbeat acknowledgement could not be applied because the nonce was no longer valid.");
+                }
+            }
+
+            return CreateValidationResponse(validation, allowedOrigin);
+        }
+        catch (ArgumentException ex)
+        {
+            return Error(HttpStatusCode.BadRequest, allowedOrigin, ex.Message);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return JsonResponse(HttpStatusCode.NotFound, allowedOrigin, new { message = ex.Message });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return JsonResponse(HttpStatusCode.Conflict, allowedOrigin, new { message = ex.Message });
+        }
     }
 
     private async Task<WebPubSubUpstreamResponse> HandleInputAsync(
@@ -246,6 +319,7 @@ public sealed class WebPubSubUpstreamHandler
         {
             var replayResponse = await _orchestrator.ReplayAsync(envelope.SessionId, envelope, cancellationToken).ConfigureAwait(false);
             await _relayPublisher.PublishEnvelopeAsync(replayResponse, cancellationToken).ConfigureAwait(false);
+            _livenessManager.RecordClientActivity(envelope.SessionId);
 
             _logger.LogDebug(
                 "Published replay response {ReplayMessageId} for replay request {ReplayRequestMessageId} for project {ProjectId} session {SessionId} through session group {SessionGroup} from connection {ConnectionId}.",
@@ -296,6 +370,7 @@ public sealed class WebPubSubUpstreamHandler
         };
 
     private static bool IsSupportedEventType(string eventType) =>
+        string.Equals(eventType, HeartbeatCloudEventType, StringComparison.OrdinalIgnoreCase) ||
         string.Equals(eventType, InputCloudEventType, StringComparison.OrdinalIgnoreCase) ||
         string.Equals(eventType, ReplayCloudEventType, StringComparison.OrdinalIgnoreCase);
 

--- a/src/SquadScout.Broker/Relay/InMemorySessionRelay.cs
+++ b/src/SquadScout.Broker/Relay/InMemorySessionRelay.cs
@@ -11,6 +11,7 @@ namespace SquadScout.Broker.Relay;
 
 public sealed class InMemorySessionRelay : ISessionRelay, IAsyncDisposable
 {
+    private readonly ISessionLivenessManager _livenessManager;
     private readonly IProjectCatalog _projectCatalog;
     private readonly ISessionOrchestrator _orchestrator;
     private readonly IPtyHost _ptyHost;
@@ -25,6 +26,7 @@ public sealed class InMemorySessionRelay : ISessionRelay, IAsyncDisposable
         ISessionOrchestrator orchestrator,
         IPtyHost ptyHost,
         PtySessionEnvelopePump ptyPump,
+        ISessionLivenessManager livenessManager,
         ISessionGroupResolver sessionGroupResolver,
         ILogger<InMemorySessionRelay> logger)
     {
@@ -32,6 +34,7 @@ public sealed class InMemorySessionRelay : ISessionRelay, IAsyncDisposable
         _orchestrator = orchestrator ?? throw new ArgumentNullException(nameof(orchestrator));
         _ptyHost = ptyHost ?? throw new ArgumentNullException(nameof(ptyHost));
         _ptyPump = ptyPump ?? throw new ArgumentNullException(nameof(ptyPump));
+        _livenessManager = livenessManager ?? throw new ArgumentNullException(nameof(livenessManager));
         _sessionGroupResolver = sessionGroupResolver ?? throw new ArgumentNullException(nameof(sessionGroupResolver));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -64,6 +67,8 @@ public sealed class InMemorySessionRelay : ISessionRelay, IAsyncDisposable
                 throw new InvalidOperationException($"An active PTY session already exists for session '{session.SessionId}'.");
             }
 
+            _livenessManager.RegisterSession(session.SessionId);
+            activeSession.HeartbeatTask = RunHeartbeatLoopAsync(session.SessionId, activeSession);
             activeSession.PumpTask = RunPumpLoopAsync(session.SessionId, activeSession);
             return session with { State = SessionState.Running };
         }
@@ -118,6 +123,7 @@ public sealed class InMemorySessionRelay : ISessionRelay, IAsyncDisposable
                     session.State,
                     $"Session '{session.SessionId}' is already stopping for project '{session.ProjectId}'.");
             }
+
         }
         finally
         {
@@ -184,7 +190,7 @@ public sealed class InMemorySessionRelay : ISessionRelay, IAsyncDisposable
                     $"Session '{sessionId}' is stopping and no longer accepts input.");
             }
 
-            return await _orchestrator.AcceptClientMessageAsync(
+            var validation = await _orchestrator.AcceptClientMessageAsync(
                 sessionId,
                 envelope,
                 async (acceptedEnvelope, token) =>
@@ -198,6 +204,13 @@ public sealed class InMemorySessionRelay : ISessionRelay, IAsyncDisposable
                     await activeSession.PtySession.WriteAsync(acceptedEnvelope.Payload.Content, token).ConfigureAwait(false);
                 },
                 cancellationToken).ConfigureAwait(false);
+
+            if (validation.IsAccepted)
+            {
+                _livenessManager.RecordClientActivity(sessionId);
+            }
+
+            return validation;
         }
         finally
         {
@@ -215,6 +228,7 @@ public sealed class InMemorySessionRelay : ISessionRelay, IAsyncDisposable
             try
             {
                 await activeSession.PtySession.TerminateAsync().ConfigureAwait(false);
+                activeSession.CancelBackgroundWork();
                 await activeSession.PumpTask.ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -409,9 +423,71 @@ public sealed class InMemorySessionRelay : ISessionRelay, IAsyncDisposable
         }
         finally
         {
+            _livenessManager.UnregisterSession(sessionId);
+            activeSession.CancelBackgroundWork();
             _activeSessions.TryRemove(sessionId, out _);
+            try
+            {
+                await activeSession.HeartbeatTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Heartbeat loop finished with a non-fatal error for session {SessionId}.", sessionId);
+            }
+
             await SafeDisposeAsync(activeSession.PtySession).ConfigureAwait(false);
             activeSession.Dispose();
+        }
+    }
+
+    private async Task RunHeartbeatLoopAsync(string sessionId, ActiveRelaySession activeSession)
+    {
+        try
+        {
+            while (!activeSession.LifetimeToken.IsCancellationRequested)
+            {
+                await Task.Delay(_livenessManager.HeartbeatInterval, activeSession.LifetimeToken).ConfigureAwait(false);
+
+                if (_livenessManager.HasTimedOut(sessionId))
+                {
+                    _logger.LogWarning(
+                        "Session {SessionId} exceeded the client liveness timeout after {TimeoutSeconds} seconds without accepted activity. Terminating the PTY session.",
+                        sessionId,
+                        _livenessManager.LivenessTimeout.TotalSeconds);
+
+                    activeSession.TryBeginStop();
+                    activeSession.CancelBackgroundWork();
+                    try
+                    {
+                        await activeSession.PtySession.TerminateAsync().ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "PTY termination failed after client liveness timeout for session {SessionId}.", sessionId);
+                    }
+
+                    return;
+                }
+
+                await _orchestrator.RecordBrokerMessageAsync(
+                        sessionId,
+                        new BrokerEnvelopeCommand<HeartbeatPayload>
+                        {
+                            MessageType = SessionMessageType.Heartbeat,
+                            MessageId = $"heartbeat-{sessionId}-{Interlocked.Increment(ref _nextMessageId)}",
+                            CorrelationId = $"pty-session:{sessionId}",
+                            TimestampUtc = DateTimeOffset.UtcNow,
+                            Payload = _livenessManager.IssueHeartbeat(sessionId)
+                        },
+                        activeSession.LifetimeToken)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (activeSession.LifetimeToken.IsCancellationRequested)
+        {
         }
     }
 
@@ -482,13 +558,25 @@ public sealed class InMemorySessionRelay : ISessionRelay, IAsyncDisposable
 
         public Task PumpTask { get; set; } = Task.CompletedTask;
 
+        public Task HeartbeatTask { get; set; } = Task.CompletedTask;
+
         public SemaphoreSlim StopInputGate { get; } = new(1, 1);
+
+        public CancellationToken LifetimeToken => _lifetimeCts.Token;
 
         public bool IsStopRequested => Volatile.Read(ref _stopRequested) == 1;
 
         public bool TryBeginStop() => Interlocked.CompareExchange(ref _stopRequested, 1, 0) == 0;
 
         public void ResetStopRequest() => Interlocked.Exchange(ref _stopRequested, 0);
+
+        public void CancelBackgroundWork()
+        {
+            if (!_lifetimeCts.IsCancellationRequested)
+            {
+                _lifetimeCts.Cancel();
+            }
+        }
 
         public void Dispose()
         {
@@ -497,7 +585,11 @@ public sealed class InMemorySessionRelay : ISessionRelay, IAsyncDisposable
                 return;
             }
 
+            CancelBackgroundWork();
+            _lifetimeCts.Dispose();
             StopInputGate.Dispose();
         }
+
+        private readonly CancellationTokenSource _lifetimeCts = new();
     }
 }

--- a/src/SquadScout.Broker/Sessions/ISessionLivenessManager.cs
+++ b/src/SquadScout.Broker/Sessions/ISessionLivenessManager.cs
@@ -1,0 +1,24 @@
+using SquadScout.Contracts.Messages;
+
+namespace SquadScout.Broker.Sessions;
+
+public interface ISessionLivenessManager
+{
+    TimeSpan HeartbeatInterval { get; }
+
+    TimeSpan LivenessTimeout { get; }
+
+    void RegisterSession(string sessionId);
+
+    void UnregisterSession(string sessionId);
+
+    HeartbeatPayload IssueHeartbeat(string sessionId);
+
+    bool CanAcceptHeartbeat(string sessionId, HeartbeatPayload payload, out string validationError);
+
+    bool TryCommitHeartbeat(string sessionId, HeartbeatPayload payload);
+
+    void RecordClientActivity(string sessionId);
+
+    bool HasTimedOut(string sessionId);
+}

--- a/src/SquadScout.Broker/Sessions/SessionLivenessManager.cs
+++ b/src/SquadScout.Broker/Sessions/SessionLivenessManager.cs
@@ -1,0 +1,228 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using SquadScout.Contracts.Messages;
+
+namespace SquadScout.Broker.Sessions;
+
+public sealed class SessionLivenessManager : ISessionLivenessManager
+{
+    private readonly ConcurrentDictionary<string, SessionLivenessState> _sessions = new(StringComparer.OrdinalIgnoreCase);
+    private readonly string _senderInstanceId;
+    private readonly TimeProvider _timeProvider;
+
+    public SessionLivenessManager()
+        : this(TimeProvider.System)
+    {
+    }
+
+    public SessionLivenessManager(
+        TimeProvider timeProvider,
+        TimeSpan? heartbeatInterval = null,
+        TimeSpan? livenessTimeout = null,
+        string? senderInstanceId = null)
+    {
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+
+        HeartbeatInterval = heartbeatInterval ?? TimeSpan.FromSeconds(SessionHeartbeatDefaults.ExpectedIntervalSeconds);
+        LivenessTimeout = livenessTimeout ?? TimeSpan.FromSeconds(SessionHeartbeatDefaults.LivenessTimeoutSeconds);
+        if (HeartbeatInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(heartbeatInterval), "Heartbeat interval must be positive.");
+        }
+
+        if (LivenessTimeout < HeartbeatInterval)
+        {
+            throw new ArgumentOutOfRangeException(nameof(livenessTimeout), "Liveness timeout must be greater than or equal to the heartbeat interval.");
+        }
+
+        _senderInstanceId = string.IsNullOrWhiteSpace(senderInstanceId)
+            ? Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID") ?? $"broker-{Environment.ProcessId}-{Guid.NewGuid():n}"
+            : senderInstanceId;
+    }
+
+    public TimeSpan HeartbeatInterval { get; }
+
+    public TimeSpan LivenessTimeout { get; }
+
+    public void RegisterSession(string sessionId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        var now = _timeProvider.GetUtcNow();
+        _sessions.AddOrUpdate(
+            sessionId,
+            _ => new SessionLivenessState(now),
+            (_, existing) =>
+            {
+                lock (existing.SyncRoot)
+                {
+                    existing.LastClientActivityUtc = now;
+                    existing.OutstandingNonces.Clear();
+                }
+
+                return existing;
+            });
+    }
+
+    public void UnregisterSession(string sessionId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            return;
+        }
+
+        _sessions.TryRemove(sessionId, out _);
+    }
+
+    public HeartbeatPayload IssueHeartbeat(string sessionId)
+    {
+        var state = GetRequiredState(sessionId);
+        var now = _timeProvider.GetUtcNow();
+        var expiresAtUtc = now + LivenessTimeout;
+        var nonce = CreateNonce();
+
+        lock (state.SyncRoot)
+        {
+            PruneExpiredNoncesLocked(state, now);
+            state.OutstandingNonces[nonce] = expiresAtUtc;
+        }
+
+        return new HeartbeatPayload
+        {
+            ExpectedIntervalSeconds = Math.Max(1, (int)Math.Round(HeartbeatInterval.TotalSeconds)),
+            LivenessTimeoutSeconds = Math.Max(1, (int)Math.Round(LivenessTimeout.TotalSeconds)),
+            SenderInstanceId = _senderInstanceId,
+            Nonce = nonce
+        };
+    }
+
+    public bool CanAcceptHeartbeat(string sessionId, HeartbeatPayload payload, out string validationError)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        if (!_sessions.TryGetValue(sessionId, out var state))
+        {
+            validationError = $"Session '{sessionId}' is not tracking broker heartbeats.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(payload.AcknowledgedNonce))
+        {
+            validationError = "Heartbeat acknowledgements must echo the broker nonce.";
+            return false;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        lock (state.SyncRoot)
+        {
+            PruneExpiredNoncesLocked(state, now);
+            if (!state.OutstandingNonces.ContainsKey(payload.AcknowledgedNonce))
+            {
+                validationError = "Heartbeat acknowledgement nonce is stale, unknown, or already consumed.";
+                return false;
+            }
+        }
+
+        validationError = string.Empty;
+        return true;
+    }
+
+    public bool TryCommitHeartbeat(string sessionId, HeartbeatPayload payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        if (!_sessions.TryGetValue(sessionId, out var state) || string.IsNullOrWhiteSpace(payload.AcknowledgedNonce))
+        {
+            return false;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        lock (state.SyncRoot)
+        {
+            PruneExpiredNoncesLocked(state, now);
+            if (!state.OutstandingNonces.Remove(payload.AcknowledgedNonce))
+            {
+                return false;
+            }
+
+            state.LastClientActivityUtc = now;
+            return true;
+        }
+    }
+
+    public void RecordClientActivity(string sessionId)
+    {
+        if (!_sessions.TryGetValue(sessionId, out var state))
+        {
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        lock (state.SyncRoot)
+        {
+            state.LastClientActivityUtc = now;
+            PruneExpiredNoncesLocked(state, now);
+        }
+    }
+
+    public bool HasTimedOut(string sessionId)
+    {
+        if (!_sessions.TryGetValue(sessionId, out var state))
+        {
+            return false;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        lock (state.SyncRoot)
+        {
+            PruneExpiredNoncesLocked(state, now);
+            return now - state.LastClientActivityUtc >= LivenessTimeout;
+        }
+    }
+
+    private SessionLivenessState GetRequiredState(string sessionId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        if (_sessions.TryGetValue(sessionId, out var state))
+        {
+            return state;
+        }
+
+        throw new KeyNotFoundException($"Session '{sessionId}' is not tracking broker heartbeats.");
+    }
+
+    private static string CreateNonce()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        RandomNumberGenerator.Fill(buffer);
+        return Convert.ToHexString(buffer);
+    }
+
+    private static void PruneExpiredNoncesLocked(SessionLivenessState state, DateTimeOffset now)
+    {
+        if (state.OutstandingNonces.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var expiredNonce in state.OutstandingNonces
+                     .Where(pair => pair.Value <= now)
+                     .Select(pair => pair.Key)
+                     .ToArray())
+        {
+            state.OutstandingNonces.Remove(expiredNonce);
+        }
+    }
+
+    private sealed class SessionLivenessState
+    {
+        public SessionLivenessState(DateTimeOffset lastClientActivityUtc)
+        {
+            LastClientActivityUtc = lastClientActivityUtc;
+        }
+
+        public object SyncRoot { get; } = new();
+
+        public Dictionary<string, DateTimeOffset> OutstandingNonces { get; } = new(StringComparer.Ordinal);
+
+        public DateTimeOffset LastClientActivityUtc { get; set; }
+    }
+}

--- a/src/SquadScout.Contracts/Messages/HeartbeatPayload.cs
+++ b/src/SquadScout.Contracts/Messages/HeartbeatPayload.cs
@@ -4,7 +4,13 @@ public sealed record HeartbeatPayload
 {
     public bool ReplayRequested { get; init; }
 
-    public int ExpectedIntervalSeconds { get; init; } = 30;
+    public int ExpectedIntervalSeconds { get; init; } = SessionHeartbeatDefaults.ExpectedIntervalSeconds;
 
-    public string SenderInstanceId { get; init; } = string.Empty;
+    public int? LivenessTimeoutSeconds { get; init; }
+
+    public string? SenderInstanceId { get; init; }
+
+    public string? Nonce { get; init; }
+
+    public string? AcknowledgedNonce { get; init; }
 }

--- a/src/SquadScout.Contracts/Messages/SessionHeartbeatDefaults.cs
+++ b/src/SquadScout.Contracts/Messages/SessionHeartbeatDefaults.cs
@@ -1,0 +1,8 @@
+namespace SquadScout.Contracts.Messages;
+
+public static class SessionHeartbeatDefaults
+{
+    public const int ExpectedIntervalSeconds = 15;
+
+    public const int LivenessTimeoutSeconds = 45;
+}

--- a/src/SquadScout.Contracts/Realtime/SessionUpstreamEventNames.cs
+++ b/src/SquadScout.Contracts/Realtime/SessionUpstreamEventNames.cs
@@ -4,12 +4,15 @@ namespace SquadScout.Contracts.Realtime;
 
 public static class SessionUpstreamEventNames
 {
+    public const string Heartbeat = "session-heartbeat";
+
     public const string Input = "session-input";
     public const string ReplayRequest = "session-replay";
 
     public static string Resolve(SessionMessageType messageType) =>
         messageType switch
         {
+            SessionMessageType.Heartbeat => Heartbeat,
             SessionMessageType.Input => Input,
             SessionMessageType.ReplayRequest => ReplayRequest,
             _ => throw new ArgumentOutOfRangeException(

--- a/tests/SquadScout.App.Tests/PubSubConnectionServiceTests.cs
+++ b/tests/SquadScout.App.Tests/PubSubConnectionServiceTests.cs
@@ -273,6 +273,151 @@ public sealed class PubSubConnectionServiceTests
     }
 
     [Fact]
+    public async Task BrokerHeartbeatSendsNonceAcknowledgementUsingCurrentBrokerAck()
+    {
+        var session = CreateSession();
+        var socket = new FakeWebPubSubSocket
+        {
+            ConnectFrames =
+            [
+                SystemMessage("connected", connectionId: "conn-heartbeat")
+            ],
+            OnSendAsync = command =>
+            {
+                var json = JsonDocument.Parse(command);
+                var ackId = json.RootElement.GetProperty("ackId").GetInt64();
+                return Task.FromResult<string?>(AckMessage(ackId, success: true));
+            }
+        };
+
+        await using var service = CreateService(new RecordingNegotiationClient(CreateNegotiationResponse(session)), socket);
+        await service.PrepareForSessionAsync(session);
+
+        socket.EnqueueIncoming(GroupMessage(CreateBrokerEnvelope(session, sequence: 1)));
+        await WaitForAsync(() => service.RecentTraffic.Count == 1);
+
+        socket.EnqueueIncoming(GroupMessage(CreateBrokerHeartbeatEnvelope(session, nonce: "nonce-123")));
+        await WaitForAsync(() => socket.SentTexts.Count >= 2);
+
+        using var heartbeatCommand = JsonDocument.Parse(socket.SentTexts[1]);
+        Assert.Equal(SessionUpstreamEventNames.Heartbeat, heartbeatCommand.RootElement.GetProperty("event").GetString());
+        var envelope = heartbeatCommand.RootElement.GetProperty("data")
+            .Deserialize<MessageEnvelope<HeartbeatPayload>>(SessionMessageSerializer.DefaultOptions);
+
+        Assert.NotNull(envelope);
+        Assert.Equal(SessionMessageType.Heartbeat, envelope!.MessageType);
+        Assert.Equal(MessageDirection.ClientToBroker, envelope.Direction);
+        Assert.Equal(1, envelope.ClientSequence);
+        Assert.Equal(1, envelope.AcknowledgedSequence);
+        Assert.Equal("nonce-123", envelope.Payload.AcknowledgedNonce);
+    }
+
+    [Fact]
+    public async Task BrokerHeartbeatTimeoutClosesTransportAndFaultsStatus()
+    {
+        var session = CreateSession();
+        var clock = new MutableClock(new DateTimeOffset(2026, 03, 26, 10, 00, 00, TimeSpan.Zero));
+        var delay = new ControlledDelay();
+        var socket = new FakeWebPubSubSocket
+        {
+            ConnectFrames =
+            [
+                SystemMessage("connected", connectionId: "conn-heartbeat-timeout")
+            ],
+            OnSendAsync = command =>
+            {
+                var json = JsonDocument.Parse(command);
+                var ackId = json.RootElement.GetProperty("ackId").GetInt64();
+                return Task.FromResult<string?>(AckMessage(ackId, success: true));
+            }
+        };
+
+        await using var service = CreateService(
+            new RecordingNegotiationClient(CreateNegotiationResponse(session, refreshAtUtc: DateTimeOffset.MinValue)),
+            clock.GetUtcNow,
+            delay.DelayAsync,
+            socket);
+        await service.PrepareForSessionAsync(session);
+
+        socket.EnqueueIncoming(GroupMessage(CreateBrokerHeartbeatEnvelope(session, nonce: "nonce-timeout", timeoutSeconds: 3)));
+        await WaitForAsync(() => delay.RequestedDelays.Count == 1 && socket.SentTexts.Count >= 2);
+
+        clock.Advance(TimeSpan.FromSeconds(4));
+        delay.ReleaseNext();
+
+        await WaitForAsync(() => service.CurrentStatus.State == MessageConnectionState.Faulted);
+
+        Assert.Equal(WebSocketState.Closed, socket.State);
+        Assert.Contains("heartbeat timed out", service.CurrentStatus.FailureReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReconnectAsyncAfterHeartbeatTimeoutRequestsReplayFromLastAcknowledgedSequence()
+    {
+        var session = CreateSession();
+        var clock = new MutableClock(new DateTimeOffset(2026, 03, 26, 10, 00, 00, TimeSpan.Zero));
+        var delay = new ControlledDelay();
+        var firstSocket = new FakeWebPubSubSocket
+        {
+            ConnectFrames =
+            [
+                SystemMessage("connected", connectionId: "conn-heartbeat-1")
+            ],
+            OnSendAsync = command =>
+            {
+                var json = JsonDocument.Parse(command);
+                var ackId = json.RootElement.GetProperty("ackId").GetInt64();
+                return Task.FromResult<string?>(AckMessage(ackId, success: true));
+            }
+        };
+
+        var secondSocket = new FakeWebPubSubSocket
+        {
+            ConnectFrames =
+            [
+                SystemMessage("connected", connectionId: "conn-heartbeat-2")
+            ],
+            OnSendAsync = command =>
+            {
+                var json = JsonDocument.Parse(command);
+                var ackId = json.RootElement.GetProperty("ackId").GetInt64();
+                return Task.FromResult<string?>(AckMessage(ackId, success: true));
+            }
+        };
+
+        await using var service = CreateService(
+            new RecordingNegotiationClient(CreateNegotiationResponse(session, refreshAtUtc: DateTimeOffset.MinValue)),
+            clock.GetUtcNow,
+            delay.DelayAsync,
+            firstSocket,
+            secondSocket);
+        await service.PrepareForSessionAsync(session);
+
+        firstSocket.EnqueueIncoming(GroupMessage(CreateBrokerEnvelope(session, sequence: 1)));
+        await WaitForAsync(() => service.RecentTraffic.Count == 1);
+
+        firstSocket.EnqueueIncoming(GroupMessage(CreateBrokerHeartbeatEnvelope(session, nonce: "nonce-reconnect", timeoutSeconds: 3)));
+        await WaitForAsync(() => delay.RequestedDelays.Count == 1 && firstSocket.SentTexts.Count >= 2);
+
+        clock.Advance(TimeSpan.FromSeconds(4));
+        delay.ReleaseNext();
+        await WaitForAsync(() => service.CurrentStatus.State == MessageConnectionState.Faulted);
+
+        var reconnectStatus = await service.ReconnectAsync();
+        await WaitForAsync(() => secondSocket.SentTexts.Count >= 2);
+
+        using var replayCommand = JsonDocument.Parse(secondSocket.SentTexts[1]);
+        var replayRequest = replayCommand.RootElement.GetProperty("data")
+            .Deserialize<MessageEnvelope<ReplayRequestPayload>>(SessionMessageSerializer.DefaultOptions);
+
+        Assert.NotNull(replayRequest);
+        Assert.Equal(MessageConnectionState.Connected, reconnectStatus.State);
+        Assert.Equal(ReplayRequestReason.ReconnectResume, replayRequest!.Payload.Reason);
+        Assert.Equal(2, replayRequest.Payload.FromSequenceInclusive);
+        Assert.Equal(1, replayRequest.AcknowledgedSequence);
+    }
+
+    [Fact]
     public async Task PrepareForSessionAsync_WithResumeStateRequestsClientRecoveryReplay()
     {
         var session = CreateSession();
@@ -1165,6 +1310,30 @@ public sealed class PubSubConnectionServiceTests
             }
         };
 
+    private static MessageEnvelope<HeartbeatPayload> CreateBrokerHeartbeatEnvelope(
+        SessionDescriptor session,
+        string nonce,
+        int timeoutSeconds = SessionHeartbeatDefaults.LivenessTimeoutSeconds,
+        int expectedIntervalSeconds = SessionHeartbeatDefaults.ExpectedIntervalSeconds) =>
+        new()
+        {
+            ProjectId = session.ProjectId,
+            SessionId = session.SessionId,
+            Generation = SessionEnvelopeContract.InitialGeneration,
+            MessageType = SessionMessageType.Heartbeat,
+            Direction = MessageDirection.BrokerToClient,
+            TimestampUtc = DateTimeOffset.UtcNow,
+            MessageId = $"heartbeat-{nonce}",
+            CorrelationId = $"broker-session:{session.SessionId}",
+            Payload = new HeartbeatPayload
+            {
+                ExpectedIntervalSeconds = expectedIntervalSeconds,
+                LivenessTimeoutSeconds = timeoutSeconds,
+                SenderInstanceId = "broker-tests",
+                Nonce = nonce
+            }
+        };
+
     private static MessageEnvelope<ReplayResponsePayload> CreateReplayResponseEnvelope(
         SessionDescriptor session,
         long generation = SessionEnvelopeContract.InitialGeneration,
@@ -1414,6 +1583,33 @@ public sealed class PubSubConnectionServiceTests
             }
 
             _pendingDelays.Dequeue().TrySetResult(true);
+        }
+    }
+
+    private sealed class MutableClock
+    {
+        private readonly object _sync = new();
+        private DateTimeOffset _utcNow;
+
+        public MutableClock(DateTimeOffset utcNow)
+        {
+            _utcNow = utcNow;
+        }
+
+        public DateTimeOffset GetUtcNow()
+        {
+            lock (_sync)
+            {
+                return _utcNow;
+            }
+        }
+
+        public void Advance(TimeSpan delta)
+        {
+            lock (_sync)
+            {
+                _utcNow = _utcNow.Add(delta);
+            }
         }
     }
 

--- a/tests/SquadScout.App.Tests/PubSubConnectionServiceTests.cs
+++ b/tests/SquadScout.App.Tests/PubSubConnectionServiceTests.cs
@@ -352,6 +352,48 @@ public sealed class PubSubConnectionServiceTests
     }
 
     [Fact]
+    public async Task NewHeartbeatExtendsDeadlineWithoutTriggeringStaleTimeout()
+    {
+        var session = CreateSession();
+        var clock = new MutableClock(new DateTimeOffset(2026, 03, 26, 10, 00, 00, TimeSpan.Zero));
+        var delay = new ControlledDelay();
+        var socket = new FakeWebPubSubSocket
+        {
+            ConnectFrames =
+            [
+                SystemMessage("connected", connectionId: "conn-heartbeat-extend")
+            ],
+            OnSendAsync = command =>
+            {
+                var json = JsonDocument.Parse(command);
+                var ackId = json.RootElement.GetProperty("ackId").GetInt64();
+                return Task.FromResult<string?>(AckMessage(ackId, success: true));
+            }
+        };
+
+        await using var service = CreateService(
+            new RecordingNegotiationClient(CreateNegotiationResponse(session, refreshAtUtc: DateTimeOffset.MinValue)),
+            clock.GetUtcNow,
+            delay.DelayAsync,
+            socket);
+        await service.PrepareForSessionAsync(session);
+
+        socket.EnqueueIncoming(GroupMessage(CreateBrokerHeartbeatEnvelope(session, nonce: "nonce-initial", timeoutSeconds: 3)));
+        await WaitForAsync(() => delay.RequestedDelays.Count == 1 && socket.SentTexts.Count >= 2);
+
+        clock.Advance(TimeSpan.FromSeconds(1));
+        socket.EnqueueIncoming(GroupMessage(CreateBrokerHeartbeatEnvelope(session, nonce: "nonce-refresh", timeoutSeconds: 5)));
+        await WaitForAsync(() => socket.SentTexts.Count >= 3);
+
+        clock.Advance(TimeSpan.FromSeconds(3));
+        delay.ReleaseNext();
+        await Task.Delay(100);
+
+        Assert.Equal(MessageConnectionState.Connected, service.CurrentStatus.State);
+        Assert.Equal(WebSocketState.Open, socket.State);
+    }
+
+    [Fact]
     public async Task ReconnectAsyncAfterHeartbeatTimeoutRequestsReplayFromLastAcknowledgedSequence()
     {
         var session = CreateSession();

--- a/tests/SquadScout.Broker.Tests/OrleansSessionGrainTests.cs
+++ b/tests/SquadScout.Broker.Tests/OrleansSessionGrainTests.cs
@@ -348,6 +348,7 @@ public sealed class OrleansSessionGrainTests
             orchestrator,
             ptyHost,
             new PtySessionEnvelopePump(orchestrator),
+            new SessionLivenessManager(TimeProvider.System, senderInstanceId: "broker-tests"),
             new SessionGroupResolver(),
             Microsoft.Extensions.Logging.Abstractions.NullLogger<InMemorySessionRelay>.Instance);
 

--- a/tests/SquadScout.Broker.Tests/PubSubUpstreamHandlerTests.cs
+++ b/tests/SquadScout.Broker.Tests/PubSubUpstreamHandlerTests.cs
@@ -66,6 +66,39 @@ public sealed class PubSubUpstreamHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsyncForHeartbeatEventRequiresCurrentBrokerNonce()
+    {
+        var orchestrator = new RecordingSessionOrchestrator();
+        var livenessManager = new SessionLivenessManager(TimeProvider.System, senderInstanceId: "broker-tests");
+        livenessManager.RegisterSession("session-abc");
+        var brokerHeartbeat = livenessManager.IssueHeartbeat("session-abc");
+        var handler = CreateHandler(orchestrator: orchestrator, livenessManager: livenessManager);
+        using var body = CreateJsonBody(CreateHeartbeatEnvelope(acknowledgedNonce: brokerHeartbeat.Nonce!));
+        var headers = CreateSignedHeaders($"azure.webpubsub.user.{SessionUpstreamEventNames.Heartbeat}");
+
+        var response = await handler.HandleAsync("POST", headers, body, CancellationToken.None);
+
+        Assert.Equal(System.Net.HttpStatusCode.NoContent, response.StatusCode);
+        Assert.NotNull(orchestrator.LastHeartbeatEnvelope);
+        Assert.False(livenessManager.CanAcceptHeartbeat("session-abc", CreateHeartbeatEnvelope(acknowledgedNonce: brokerHeartbeat.Nonce!).Payload, out _));
+    }
+
+    [Fact]
+    public async Task HandleAsyncForHeartbeatEventRejectsUnknownNonce()
+    {
+        var livenessManager = new SessionLivenessManager(TimeProvider.System, senderInstanceId: "broker-tests");
+        livenessManager.RegisterSession("session-abc");
+        var handler = CreateHandler(livenessManager: livenessManager);
+        using var body = CreateJsonBody(CreateHeartbeatEnvelope(acknowledgedNonce: "unknown-nonce"));
+        var headers = CreateSignedHeaders($"azure.webpubsub.user.{SessionUpstreamEventNames.Heartbeat}");
+
+        var response = await handler.HandleAsync("POST", headers, body, CancellationToken.None);
+
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains("nonce", response.Body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task HandleAsyncRejectsMalformedInputEnvelopeWithoutCallingRelay()
     {
         var relay = new RecordingSessionRelay();
@@ -90,7 +123,7 @@ public sealed class PubSubUpstreamHandlerTests
             CancellationToken.None);
 
         Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
-        Assert.Contains("input or replay-request envelope", response.Body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("heartbeat, input, or replay-request envelope", response.Body, StringComparison.OrdinalIgnoreCase);
         Assert.Null(relay.LastInputEnvelope);
     }
 
@@ -270,6 +303,7 @@ public sealed class PubSubUpstreamHandlerTests
         RecordingSessionRelay? relay = null,
         RecordingSessionOrchestrator? orchestrator = null,
         RecordingRelayPublisher? publisher = null,
+        ISessionLivenessManager? livenessManager = null,
         AzureWebPubSubOptions? options = null) =>
         new(
             new WebPubSubUpstreamAuthenticator(
@@ -277,6 +311,7 @@ public sealed class PubSubUpstreamHandlerTests
                 NullLogger<WebPubSubUpstreamAuthenticator>.Instance),
             relay ?? new RecordingSessionRelay(),
             orchestrator ?? new RecordingSessionOrchestrator(),
+            livenessManager ?? new SessionLivenessManager(TimeProvider.System, senderInstanceId: "broker-tests"),
             publisher ?? new RecordingRelayPublisher(),
             NullLogger<WebPubSubUpstreamHandler>.Instance);
 
@@ -321,6 +356,26 @@ public sealed class PubSubUpstreamHandlerTests
             Payload = new InputChunkPayload
             {
                 Content = "status --json\n"
+            }
+        };
+
+    private static MessageEnvelope<HeartbeatPayload> CreateHeartbeatEnvelope(
+        long clientSequence = 1,
+        string acknowledgedNonce = "nonce-1") =>
+        new()
+        {
+            ProjectId = "broker",
+            SessionId = "session-abc",
+            Generation = SessionEnvelopeContract.InitialGeneration,
+            MessageType = SessionMessageType.Heartbeat,
+            Direction = MessageDirection.ClientToBroker,
+            ClientSequence = clientSequence,
+            MessageId = $"client-heartbeat-{clientSequence}",
+            CorrelationId = "corr-heartbeat",
+            Payload = new HeartbeatPayload
+            {
+                SenderInstanceId = "mobile-tests",
+                AcknowledgedNonce = acknowledgedNonce
             }
         };
 
@@ -450,6 +505,15 @@ public sealed class PubSubUpstreamHandlerTests
 
     private sealed class RecordingSessionOrchestrator : ISessionOrchestrator
     {
+        public SequenceValidationResult ValidationResult { get; set; } = new()
+        {
+            Status = SequenceValidationStatus.Accepted,
+            Generation = SessionEnvelopeContract.InitialGeneration,
+            ClientSequence = 1
+        };
+
+        public MessageEnvelope<HeartbeatPayload>? LastHeartbeatEnvelope { get; private set; }
+
         public MessageEnvelope<ReplayRequestPayload>? LastReplayRequest { get; private set; }
 
         public MessageEnvelope<ReplayResponsePayload> ReplayResponse { get; set; } = new()
@@ -482,8 +546,15 @@ public sealed class PubSubUpstreamHandlerTests
         public Task<SequenceValidationResult> ValidateClientMessageAsync<TPayload>(
             string sessionId,
             MessageEnvelope<TPayload> envelope,
-            CancellationToken cancellationToken = default) =>
-            throw new NotSupportedException();
+            CancellationToken cancellationToken = default)
+        {
+            if (envelope is MessageEnvelope<HeartbeatPayload> heartbeat)
+            {
+                LastHeartbeatEnvelope = heartbeat;
+            }
+
+            return Task.FromResult(ValidationResult);
+        }
 
         public Task<SequenceValidationResult> AcceptClientMessageAsync<TPayload>(
             string sessionId,

--- a/tests/SquadScout.Broker.Tests/SessionLivenessManagerTests.cs
+++ b/tests/SquadScout.Broker.Tests/SessionLivenessManagerTests.cs
@@ -1,0 +1,87 @@
+using SquadScout.Broker.Sessions;
+using SquadScout.Contracts.Messages;
+
+namespace SquadScout.Broker.Tests;
+
+public sealed class SessionLivenessManagerTests
+{
+    [Fact]
+    public void TryCommitHeartbeatConsumesOutstandingNonceAndRefreshesActivity()
+    {
+        var timeProvider = new MutableTimeProvider(new DateTimeOffset(2026, 03, 26, 12, 00, 00, TimeSpan.Zero));
+        var manager = new SessionLivenessManager(
+            timeProvider,
+            heartbeatInterval: TimeSpan.FromSeconds(10),
+            livenessTimeout: TimeSpan.FromSeconds(30),
+            senderInstanceId: "broker-tests");
+
+        manager.RegisterSession("session-abc");
+        var heartbeat = manager.IssueHeartbeat("session-abc");
+
+        Assert.True(manager.CanAcceptHeartbeat("session-abc", new HeartbeatPayload
+        {
+            AcknowledgedNonce = heartbeat.Nonce
+        }, out var validationError));
+        Assert.True(string.IsNullOrEmpty(validationError));
+
+        timeProvider.Advance(TimeSpan.FromSeconds(20));
+        Assert.True(manager.TryCommitHeartbeat("session-abc", new HeartbeatPayload
+        {
+            AcknowledgedNonce = heartbeat.Nonce
+        }));
+        Assert.False(manager.HasTimedOut("session-abc"));
+
+        Assert.False(manager.CanAcceptHeartbeat("session-abc", new HeartbeatPayload
+        {
+            AcknowledgedNonce = heartbeat.Nonce
+        }, out validationError));
+        Assert.Contains("stale", validationError, StringComparison.OrdinalIgnoreCase);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(29));
+        Assert.False(manager.HasTimedOut("session-abc"));
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        Assert.True(manager.HasTimedOut("session-abc"));
+    }
+
+    [Fact]
+    public void CanAcceptHeartbeatRejectsExpiredNonce()
+    {
+        var timeProvider = new MutableTimeProvider(new DateTimeOffset(2026, 03, 26, 12, 00, 00, TimeSpan.Zero));
+        var manager = new SessionLivenessManager(
+            timeProvider,
+            heartbeatInterval: TimeSpan.FromSeconds(5),
+            livenessTimeout: TimeSpan.FromSeconds(15),
+            senderInstanceId: "broker-tests");
+
+        manager.RegisterSession("session-abc");
+        var heartbeat = manager.IssueHeartbeat("session-abc");
+
+        timeProvider.Advance(TimeSpan.FromSeconds(15));
+
+        Assert.False(manager.CanAcceptHeartbeat("session-abc", new HeartbeatPayload
+        {
+            AcknowledgedNonce = heartbeat.Nonce
+        }, out var validationError));
+        Assert.Contains("stale", validationError, StringComparison.OrdinalIgnoreCase);
+        Assert.False(manager.TryCommitHeartbeat("session-abc", new HeartbeatPayload
+        {
+            AcknowledgedNonce = heartbeat.Nonce
+        }));
+        Assert.True(manager.HasTimedOut("session-abc"));
+    }
+
+    private sealed class MutableTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow;
+
+        public MutableTimeProvider(DateTimeOffset utcNow)
+        {
+            _utcNow = utcNow;
+        }
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan delta) => _utcNow = _utcNow.Add(delta);
+    }
+}

--- a/tests/SquadScout.Broker.Tests/SessionRelayPipelineTests.cs
+++ b/tests/SquadScout.Broker.Tests/SessionRelayPipelineTests.cs
@@ -177,6 +177,7 @@ public sealed class SessionRelayPipelineTests
             orchestrator,
             ptyHost,
             new PtySessionEnvelopePump(orchestrator),
+            CreateLivenessManager(),
             new SessionGroupResolver(),
             NullLogger<InMemorySessionRelay>.Instance);
 
@@ -243,6 +244,7 @@ public sealed class SessionRelayPipelineTests
             orchestrator,
             ptyHost,
             new PtySessionEnvelopePump(orchestrator),
+            CreateLivenessManager(),
             new SessionGroupResolver(),
             NullLogger<InMemorySessionRelay>.Instance);
 
@@ -484,7 +486,7 @@ public sealed class SessionRelayPipelineTests
         var relayPublisher = new RecordingRelayPublisher();
         var orchestrator = new InMemorySessionOrchestrator(relayPublisher, new SessionSequenceValidator(), replayBufferCapacity: 8);
         var ptyHost = new MockPtyHost();
-        return new RelayHarness(catalog, relayPublisher, orchestrator, ptyHost, new RecordingSessionGroupResolver());
+        return new RelayHarness(catalog, relayPublisher, orchestrator, ptyHost, new RecordingSessionGroupResolver(), CreateLivenessManager());
     }
 
     private static Task<RelayHarness> CreateHarnessWithoutProjectsAsync()
@@ -493,7 +495,7 @@ public sealed class SessionRelayPipelineTests
         var relayPublisher = new RecordingRelayPublisher();
         var orchestrator = new InMemorySessionOrchestrator(relayPublisher, new SessionSequenceValidator(), replayBufferCapacity: 8);
         var ptyHost = new MockPtyHost();
-        return Task.FromResult(new RelayHarness(catalog, relayPublisher, orchestrator, ptyHost, new RecordingSessionGroupResolver()));
+        return Task.FromResult(new RelayHarness(catalog, relayPublisher, orchestrator, ptyHost, new RecordingSessionGroupResolver(), CreateLivenessManager()));
     }
 
     private static string GetRepositoryRoot()
@@ -502,6 +504,15 @@ public sealed class SessionRelayPipelineTests
         Directory.CreateDirectory(root);
         return root;
     }
+
+    private static SessionLivenessManager CreateLivenessManager(
+        TimeSpan? heartbeatInterval = null,
+        TimeSpan? livenessTimeout = null) =>
+        new(
+            TimeProvider.System,
+            heartbeatInterval,
+            livenessTimeout,
+            senderInstanceId: "broker-tests");
 
     private static MessageEnvelope<InputChunkPayload> CreateInputEnvelope(
         SessionDescriptor session,
@@ -585,13 +596,15 @@ public sealed class SessionRelayPipelineTests
             RecordingRelayPublisher relayPublisher,
             InMemorySessionOrchestrator orchestrator,
             MockPtyHost ptyHost,
-            RecordingSessionGroupResolver sessionGroupResolver)
+            RecordingSessionGroupResolver sessionGroupResolver,
+            SessionLivenessManager livenessManager)
         {
             ProjectCatalog = projectCatalog;
             RelayPublisher = relayPublisher;
             Orchestrator = orchestrator;
             PtyHost = ptyHost;
             SessionGroupResolver = sessionGroupResolver;
+            LivenessManager = livenessManager;
         }
 
         public InMemoryProjectCatalog ProjectCatalog { get; }
@@ -604,12 +617,15 @@ public sealed class SessionRelayPipelineTests
 
         public RecordingSessionGroupResolver SessionGroupResolver { get; }
 
+        public SessionLivenessManager LivenessManager { get; }
+
         public InMemorySessionRelay CreateRelay() =>
             new(
                 ProjectCatalog,
                 Orchestrator,
                 PtyHost,
                 new PtySessionEnvelopePump(Orchestrator),
+                LivenessManager,
                 SessionGroupResolver,
                 NullLogger<InMemorySessionRelay>.Instance);
     }


### PR DESCRIPTION
## Summary
- add broker-driven heartbeat nonce/liveness tracking without changing replay ownership
- terminate dead relay sessions while keeping heartbeats out of the replay buffer and preserving reconnect-by-replay
- teach the MAUI transport to acknowledge broker heartbeats, detect broker heartbeat expiry, and reconnect cleanly

Closes #22

## Validation
- dotnet build .\\SquadScout.slnx -nologo
- dotnet test .\\SquadScout.slnx -nologo --no-build